### PR TITLE
Propagate version when building .deb

### DIFF
--- a/packaging/debs/Debian/debian/rules
+++ b/packaging/debs/Debian/debian/rules
@@ -27,9 +27,9 @@ override_dh_auto_install: PREFIX = /usr
 override_dh_auto_install: RMQ_ROOTDIR = $(PREFIX)/lib/rabbitmq
 override_dh_auto_install: RMQ_ERLAPP_DIR = $(RMQ_ROOTDIR)/lib/rabbitmq_server-$(VERSION)
 override_dh_auto_install:
-	dh_auto_install
+	dh_auto_install -- VERSION=$(VERSION)
 
-	$(MAKE) install-bin DESTDIR=$(DEB_DESTDIR)
+	$(MAKE) install-bin DESTDIR=$(DEB_DESTDIR) VERSION=$(VERSION)
 
 	sed -e 's|@RABBIT_LIB@|$(RMQ_ERLAPP_DIR)|g' \
 		< debian/postrm.in > debian/postrm


### PR DESCRIPTION
Otherwise rebuilding package from debian sources creates `rabbitmq-0.0.0` directory. Which leads to inability to rebuild the package. Here is the example with 3.6.6 milestone 5:

```

docker run --rm -i -t debian:jessie bash
$ apt-get update && apt-get install -y --no-install-recommends zip xsltproc xmlto unzip python-simplejson make git rsync dpkg-dev debhelper dh-systemd erlang-dev erlang-nox erlang-src fakeroot build-essential wget
$ wget https://github.com/rabbitmq/rabbitmq-server/releases/download/rabbitmq_v3_6_6_milestone5/rabbitmq-server_3.6.5.905.orig.tar.xz
$ wget https://github.com/rabbitmq/rabbitmq-server/releases/download/rabbitmq_v3_6_6_milestone5/rabbitmq-server_3.6.5.905-1.dsc
$ wget https://github.com/rabbitmq/rabbitmq-server/releases/download/rabbitmq_v3_6_6_milestone5/rabbitmq-server_3.6.5.905-1.debian.tar.gz
$ dpkg-source -x *.dsc
$ cd rabbitmq-server-3.6.5.905/
$ dpkg-buildpackage -us -uc -b # FAILS

$ ls -l debian/rabbitmq-server/usr/lib/rabbitmq/lib/ # BECAUSE OF THIS
total 4
drwxr-xr-x 6 root root 4096 Oct 18 17:00 rabbitmq_server-0.0.0

```
