### PR TITLE
Make .deb build process re-enterable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ ZIP_V_2 =
 ZIP_V = $(ZIP_V_$(V))
 
 .PHONY: $(SOURCE_DIST)
-.PHONY: clean-source-dist distclean-packages
+.PHONY: clean-source-dist distclean-packages clean-unpacked-source-dist
 
 $(SOURCE_DIST): $(ERLANG_MK_RECURSIVE_DEPS_LIST)
 	$(verbose) mkdir -p $(dir $@)
@@ -146,6 +146,7 @@ $(SOURCE_DIST): $(ERLANG_MK_RECURSIVE_DEPS_LIST)
 		find "$$dep" -maxdepth 1 -name 'LICENSE-*' -exec cp '{}' $@/deps/licensing \; ; \
 		(cd $$dep; echo "$$(basename "$$dep") $$(git rev-parse HEAD) $$(git describe --tags --exact-match 2>/dev/null || git symbolic-ref -q --short HEAD)") >> $@/git-revisions.txt; \
 	done
+	$(verbose) make -C $@/deps/rabbitmq_web_stomp patch-sockjs # With web_stomp hack compilation will not only produce artifacts, but will also change sources itself - so do it preemptively and make dpkg-source happy
 	$(verbose) cat packaging/common/LICENSE.tail >> $@/LICENSE
 	$(verbose) find $@/deps/licensing -name 'LICENSE-*' -exec cp '{}' $@ \;
 	$(verbose) for file in $$(find $@ -name '*.app.src'); do \
@@ -195,6 +196,13 @@ distclean-upgrade:
 
 distclean-packages:
 	$(gen_verbose) rm -rf -- $(PACKAGES_DIR)
+
+clean-unpacked-source-dist:
+	for d in deps/*; do \
+		if test -f $$d/Makefile; then \
+			make -C $$d clean || exit $$?; \
+		fi; \
+	done
 
 # --------------------------------------------------------------------
 # Packaging.

--- a/packaging/debs/Debian/debian/rules
+++ b/packaging/debs/Debian/debian/rules
@@ -13,7 +13,8 @@ unexport DEPS_DIR
 	dh $@ --parallel --with systemd
 
 override_dh_auto_clean:
-	$(MAKE) clean distclean-manpages
+	$(MAKE) clean clean-unpacked-source-dist distclean-manpages
+	rm -rf .erlang.mk
 
 override_dh_auto_build:
 	$(MAKE) dist manpages


### PR DESCRIPTION
This fixes some annoyances that appear when you are experimenting with .deb-packaging.

With this patch it's possible to run `dpkg-buildpackage` any number
number of times from single source directory. Otherwise `dpkg-source`
thinks that sources were modified and fails to execute.

Calling `patch-sockjs` is necessary to be sure that no files in source dist
tarball will not be touched during build.

`clean-unpacked-source-dist` is needed because `make clean` doesn't
descend into `deps/` folder, and doing `make clean APPS_DIR=deps` breaks
on `licensing/` which doesn't have makefile.
