### PR TITLE
Add write permissions to erl

### DIFF
--- a/packaging/standalone/Makefile
+++ b/packaging/standalone/Makefile
@@ -91,6 +91,7 @@ dist:
 	rm -rf $(RLS_DIR)/lib/rabbit-$(VERSION)
 
 # fix Erlang ROOTDIR
+	chmod +w $(RLS_DIR)/erts-$(ERTS_VSN)/bin/erl
 	patch -o $(RLS_DIR)/erts-$(ERTS_VSN)/bin/erl $(RLS_DIR)/erts-$(ERTS_VSN)/bin/erl.src < erl.diff
 	rm -f $(RLS_DIR)/erts-$(ERTS_VSN)/bin/erl.orig
 


### PR DESCRIPTION
Otherwise erl.diff cannot be applied:

    patch -o rabbitmq_server-3.7.0.milestone8/release/rabbitmq_server-3.7.0.milestone8/erts-8.2/bin/erl rabbitmq_server-3.7.0.milestone8/release/rabbitmq_server-3.7.0.milestone8/erts-8.2/bin/erl.src < erl.diff
    patch: **** Can't create file rabbitmq_server-3.7.0.milestone8/release/rabbitmq_server-3.7.0.milestone8/erts-8.2/bin/erl : Permission denied