### PR TITLE
OCF RA: Add new limit_nofile parameter to both OCF resource agents

### DIFF
--- a/scripts/rabbitmq-server-ha.ocf
+++ b/scripts/rabbitmq-server-ha.ocf
@@ -567,7 +567,10 @@ now() {
 }
 
 set_limits() {
-    [ ! -z $OCF_RESKEY_limit_nofile ] && ulimit -n $OCF_RESKEY_limit_nofile
+    local current_limit=$(su $OCF_RESKEY_username -s /bin/sh -c "ulimit -n")
+    if [ ! -z $OCF_RESKEY_limit_nofile -a $OCF_RESKEY_limit_nofile -gt $current_limit ] ; then
+        ulimit -n $OCF_RESKEY_limit_nofile
+    fi
 }
 
 master_score() {

--- a/scripts/rabbitmq-server-ha.ocf
+++ b/scripts/rabbitmq-server-ha.ocf
@@ -50,6 +50,7 @@ OCF_RESKEY_max_rabbitmqctl_timeouts_default=3
 OCF_RESKEY_policy_file_default="/usr/local/sbin/set_rabbitmq_policy"
 OCF_RESKEY_rmq_feature_health_check_default=true
 OCF_RESKEY_rmq_feature_local_list_queues_default=true
+OCF_RESKEY_limit_nofile_default=65535
 
 : ${HA_LOGTAG="lrmd"}
 : ${HA_LOGFACILITY="daemon"}
@@ -74,6 +75,7 @@ OCF_RESKEY_rmq_feature_local_list_queues_default=true
 : ${OCF_RESKEY_policy_file=${OCF_RESKEY_policy_file_default}}
 : ${OCF_RESKEY_rmq_feature_health_check=${OCF_RESKEY_rmq_feature_health_check_default}}
 : ${OCF_RESKEY_rmq_feature_local_list_queues=${OCF_RESKEY_rmq_feature_local_list_queues_default}}
+: ${OCF_RESKEY_limit_nofile=${OCF_RESKEY_limit_nofile_default}}
 
 #######################################################################
 
@@ -332,6 +334,14 @@ stopped/demoted.
 <content type="boolean" default="${OCF_RESKEY_rmq_feature_local_list_queues_default}" />
 </parameter>
 
+<parameter name="limit_nofile" unique="0" required="0">
+<longdesc lang="en">
+Soft and hard limit for NOFILE
+</longdesc>
+<shortdesc lang="en">NOFILE limit</shortdesc>
+<content type="string" default="${OCF_RESKEY_limit_nofile_default}" />
+</parameter>
+
 $EXTENDED_OCF_PARAMS
 
 </parameters>
@@ -554,6 +564,10 @@ su_rabbit_cmd() {
 
 now() {
     date -u +%s
+}
+
+set_limits() {
+    [ ! -z $OCF_RESKEY_limit_nofile ] && ulimit -n $OCF_RESKEY_limit_nofile
 }
 
 master_score() {
@@ -1165,6 +1179,9 @@ start_beam_process() {
     fi
 
     [ -f /etc/default/rabbitmq-server ] && . /etc/default/rabbitmq-server
+
+    # RabbitMQ requires high soft and hard limits for NOFILE
+    set_limits
 
     # run beam process
     command="${OCF_RESKEY_binary} >> \"${OCF_RESKEY_log_dir}/startup_log\" 2>/dev/null"

--- a/scripts/rabbitmq-server.ocf
+++ b/scripts/rabbitmq-server.ocf
@@ -30,6 +30,7 @@
 ##   OCF_RESKEY_mnesia_base
 ##   OCF_RESKEY_server_start_args
 ##   OCF_RESKEY_pid_file
+##   OCF_RESKEY_limit_nofile
 
 #######################################################################
 # Initialization:
@@ -44,11 +45,13 @@ OCF_RESKEY_ctl_default="/usr/sbin/rabbitmqctl"
 OCF_RESKEY_nodename_default="rabbit@localhost"
 OCF_RESKEY_log_base_default="/var/log/rabbitmq"
 OCF_RESKEY_pid_file_default="/var/run/rabbitmq/pid"
+OCF_RESKEY_limit_nofile_default="65535"
 : ${OCF_RESKEY_server=${OCF_RESKEY_server_default}}
 : ${OCF_RESKEY_ctl=${OCF_RESKEY_ctl_default}}
 : ${OCF_RESKEY_nodename=${OCF_RESKEY_nodename_default}}
 : ${OCF_RESKEY_log_base=${OCF_RESKEY_log_base_default}}
 : ${OCF_RESKEY_pid_file=${OCF_RESKEY_pid_file_default}}
+: ${OCF_RESKEY_limit_nofile=${OCF_RESKEY_limit_nofile_default}}
 
 meta_data() {
     cat <<END
@@ -144,6 +147,14 @@ Location of the file in which the pid will be stored
 <content type="string" default="${OCF_RESKEY_pid_file_default}" />
 </parameter>
 
+<parameter name="limit_nofile" unique="0" required="0">
+<longdesc lang="en">
+Soft and hard limit for NOFILE
+</longdesc>
+<shortdesc lang="en">NOFILE limit</shortdesc>
+<content type="string" default="${OCF_RESKEY_limit_nofile_default}" />
+</parameter>
+
 </parameters>
 
 <actions>
@@ -176,6 +187,7 @@ RABBITMQ_LOG_BASE=$OCF_RESKEY_log_base
 RABBITMQ_MNESIA_BASE=$OCF_RESKEY_mnesia_base
 RABBITMQ_SERVER_START_ARGS=$OCF_RESKEY_server_start_args
 RABBITMQ_PID_FILE=$OCF_RESKEY_pid_file
+RABBITMQ_LIMIT_NOFILE=$OCF_RESKEY_limit_nofile
 [ ! -z $RABBITMQ_NODENAME ] && NODENAME_ARG="-n $RABBITMQ_NODENAME"
 [ ! -z $RABBITMQ_NODENAME ]            && export RABBITMQ_NODENAME
 
@@ -202,6 +214,10 @@ export_vars() {
     [ ! -z $RABBITMQ_MNESIA_BASE ]         && export RABBITMQ_MNESIA_BASE
     [ ! -z $RABBITMQ_SERVER_START_ARGS ]   && export RABBITMQ_SERVER_START_ARGS
     [ ! -z $RABBITMQ_PID_FILE ]            && ensure_pid_dir && export RABBITMQ_PID_FILE
+}
+
+set_limits() {
+    [ ! -z $RABBITMQ_LIMIT_NOFILE ] && ulimit -n $RABBITMQ_LIMIT_NOFILE
 }
 
 rabbit_validate_partial() {
@@ -275,6 +291,9 @@ rabbit_start() {
     fi
 
     export_vars
+
+    # RabbitMQ requires high soft and hard limits for NOFILE
+    set_limits
 
     setsid sh -c "$RABBITMQ_SERVER > ${RABBITMQ_LOG_BASE}/startup_log 2> ${RABBITMQ_LOG_BASE}/startup_err" &
 

--- a/scripts/rabbitmq-server.ocf
+++ b/scripts/rabbitmq-server.ocf
@@ -217,7 +217,10 @@ export_vars() {
 }
 
 set_limits() {
-    [ ! -z $RABBITMQ_LIMIT_NOFILE ] && ulimit -n $RABBITMQ_LIMIT_NOFILE
+    local current_limit=$(su rabbitmq -s /bin/sh -c "ulimit -n")
+    if [ ! -z $RABBITMQ_LIMIT_NOFILE -a $RABBITMQ_LIMIT_NOFILE -gt $current_limit ] ; then
+        ulimit -n $RABBITMQ_LIMIT_NOFILE
+    fi
 }
 
 rabbit_validate_partial() {


### PR DESCRIPTION
This enables to change the limit of open files, as the default on
distributions is usually too low for rabbitmq. Default is 65535.

The initial change is from @aplanas, but I guess we want a similar change in the other RA.