### PR TITLE
Log rabbitmqctl's output on failure

### DIFF
--- a/scripts/rabbitmq-server.ocf
+++ b/scripts/rabbitmq-server.ocf
@@ -256,7 +256,7 @@ rabbitmqctl_action() {
     local rc
     local action
     action=$@
-    $RABBITMQ_CTL $NODENAME_ARG $action > /dev/null 2> /dev/null
+    ocf_run -q -info $RABBITMQ_CTL $NODENAME_ARG $action
     rc=$?
     case "$rc" in
         0)


### PR DESCRIPTION
It would be helpful to see rabbit's output when it exits with non-zero
status code. The log level is left at info, as it might be business as
usual that a node is not running rabbit. The -q switch prevents the
output from being logged if the return value is zero.