### PR TITLE
Require root or rabbitmq user for rabbitmq-plugins.

### DIFF
--- a/scripts/rabbitmq-script-wrapper
+++ b/scripts/rabbitmq-script-wrapper
@@ -31,7 +31,7 @@ if [ `id -u` = `id -u rabbitmq` -a "$SCRIPT" = "rabbitmq-server" ] ; then
     . "$RABBITMQ_ENV"
 
     exec /usr/lib/rabbitmq/bin/rabbitmq-server "$@" @STDOUT_STDERR_REDIRECTION@
-elif [ `id -u` = `id -u rabbitmq` -o "$SCRIPT" = "rabbitmq-plugins" ] ; then
+elif [ `id -u` = `id -u rabbitmq` ] ; then
     if [ -f $PWD/.erlang.cookie ] ; then
         export HOME=.
     fi


### PR DESCRIPTION
For some reason, the rabbitmq-plugins command could be run
from arbitrary user, which would result in errors unable to
access a cookie file or plugins configuration files.
Changed to work the same way as rabbitmqctl - require root
or rabbitmq user.

[Fixes #149425921]