### PR TITLE
Erlang/OTP 19.2 is now the minimum supported version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 sudo: required
 
+otp_release:
+  - "19.2"
+  - "19.3"
+  - "20.0"
+
 services:
   - docker
 


### PR DESCRIPTION
Part of rabbitmq/rabbitmq-server#1305.

[#149563549]