### PR TITLE
scripts/rabbitmq-script-wrapper: Run rabbitmq-plugin as root only

### DIFF
--- a/scripts/rabbitmq-script-wrapper
+++ b/scripts/rabbitmq-script-wrapper
@@ -31,7 +31,7 @@ if [ `id -u` = `id -u rabbitmq` -a "$SCRIPT" = "rabbitmq-server" ] ; then
     . "$RABBITMQ_ENV"
 
     exec /usr/lib/rabbitmq/bin/rabbitmq-server "$@" @STDOUT_STDERR_REDIRECTION@
-elif [ `id -u` = `id -u rabbitmq` ] ; then
+elif [ \( `id -u` = `id -u rabbitmq` -a "$SCRIPT" != "rabbitmq-plugins" \) -o \( `id -u` = 0 -a "$SCRIPT" = "rabbitmq-plugins" \) ] ; then
     if [ -f $PWD/.erlang.cookie ] ; then
         export HOME=.
     fi
@@ -41,7 +41,11 @@ elif [ `id -u` = 0 ] ; then
 else
     /usr/lib/rabbitmq/bin/${SCRIPT}
     echo
-    echo "Only root or rabbitmq should run ${SCRIPT}"
+    if [ "$SCRIPT" = 'rabbitmq-plugins' ]; then
+        echo "Only root should run ${SCRIPT}"
+    else
+        echo "Only root or rabbitmq should run ${SCRIPT}"
+    fi
     echo
     exit 1
 fi


### PR DESCRIPTION
The previous patch was meant to make it clear that an unprivileged user (other than `rabbitmq`) shouldn't run rabbitmq-plugins.

Unfortunately, it broke the script when called by root, because the real script was executed as `rabbitmq`. This user doesn't have write permissions to `/etc/rabbitmq` by default.

Now, rabbitmq-plugins' wrapper must be executed as root and so is the real script. This should fix the problem described above.

[#149840153]