### PR TITLE
Fixes for SELinux support

### DIFF
--- a/packaging/RPMS/Fedora/rabbitmq-server.spec
+++ b/packaging/RPMS/Fedora/rabbitmq-server.spec
@@ -81,8 +81,7 @@ install -p -D -m 0755 scripts/zsh_autocomplete.sh %{buildroot}%{_datarootdir}/zs
 mkdir -p %{buildroot}%{_sysconfdir}/rabbitmq
 
 mkdir -p %{buildroot}%{_sbindir}
-sed -e 's|@SU_RABBITMQ_SH_C@|su rabbitmq -s /bin/sh -c|' \
-	-e 's|@STDOUT_STDERR_REDIRECTION@||' \
+sed -e 's|@STDOUT_STDERR_REDIRECTION@||' \
 	< scripts/rabbitmq-script-wrapper \
 	> %{buildroot}%{_sbindir}/rabbitmqctl
 chmod 0755 %{buildroot}%{_sbindir}/rabbitmqctl

--- a/packaging/debs/Debian/debian/rules
+++ b/packaging/debs/Debian/debian/rules
@@ -31,8 +31,7 @@ override_dh_auto_install:
 
 	$(MAKE) install-bin DESTDIR=$(DEB_DESTDIR)
 
-	sed -e 's|@SU_RABBITMQ_SH_C@|su rabbitmq -s /bin/sh -c|' \
-		-e 's|@STDOUT_STDERR_REDIRECTION@|> "$$RABBITMQ_LOG_BASE/startup_log" 2> "$$RABBITMQ_LOG_BASE/startup_err"|' \
+	sed -e 's|@STDOUT_STDERR_REDIRECTION@|> "$$RABBITMQ_LOG_BASE/startup_log" 2> "$$RABBITMQ_LOG_BASE/startup_err"|' \
 		< scripts/rabbitmq-script-wrapper \
 		> $(DEB_DESTDIR)$(PREFIX)/sbin/rabbitmqctl
 	chmod 0755 $(DEB_DESTDIR)$(PREFIX)/sbin/rabbitmqctl

--- a/scripts/rabbitmq-script-wrapper
+++ b/scripts/rabbitmq-script-wrapper
@@ -81,7 +81,16 @@ exec_script_as_rabbitmq() {
 }
 
 exec_script_as_root() {
-  @SU_RABBITMQ_SH_C@ "/usr/lib/rabbitmq/bin/$SCRIPT $CMDLINE"
+  if [ -x /sbin/runuser ]
+  then
+    exec /sbin/runuser -u rabbitmq /bin/sh -c "/usr/lib/rabbitmq/bin/$SCRIPT $CMDLINE"
+  elif [ -x /bin/su ]
+  then
+    exec /bin/su rabbitmq -s /bin/sh -c "/usr/lib/rabbitmq/bin/$SCRIPT $CMDLINE"
+  else
+    echo 'No command present to run as rabbitmq user. Please ensure /bin/su or /sbin/runuser is available.' 1>&2
+    exit 1
+  fi
 }
 
 run_script_help_and_fail() {

--- a/scripts/rabbitmq-script-wrapper
+++ b/scripts/rabbitmq-script-wrapper
@@ -88,7 +88,7 @@ exec_script_as_root() {
   then
     exec /bin/su rabbitmq -s /bin/sh -c "/usr/lib/rabbitmq/bin/$SCRIPT $CMDLINE"
   else
-    echo 'No command present to run as rabbitmq user. Please ensure /bin/su or /sbin/runuser is available.' 1>&2
+    echo "Please ensure /bin/su or /sbin/runuser exists and can be executed by $USER." 1>&2
     exit 1
   fi
 }


### PR DESCRIPTION
Use `/sbin/runuser` to execute script as the `rabbitmq` user as this command
does not cause issues with SELinux. See #32 for details.