### PR TITLE
Create two different packages for OpenSuse

### DIFF
--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -74,7 +74,7 @@ packages: package-deb package-rpm package-windows package-generic-unix
 package-deb: $(SOURCE_DIST_FILE)
 	$(gen_verbose) $(MAKE) -C debs/Debian $(VARS) all $(DO_CLEAN)
 
-package-rpm-opensuse package-rpm-suse: package-rpm-opensuse1012 package-rpm-opensuse1315 
+package-rpm-suse: package-rpm-opensuse1012 package-rpm-opensuse 
 	@:
 
 package-rpm: package-rpm-rhel6 package-rpm-rhel7 package-rpm-opensuse
@@ -92,8 +92,8 @@ package-rpm-rhel7: $(SOURCE_DIST_FILE)
 package-rpm-opensuse1012: $(SOURCE_DIST_FILE)
 	$(gen_verbose) $(MAKE) -C RPMS/Fedora $(VARS) RPM_OS=suse1012 all $(DO_CLEAN)
 
-package-rpm-opensuse1315: $(SOURCE_DIST_FILE)
-	$(gen_verbose) $(MAKE) -C RPMS/Fedora $(VARS) RPM_OS=suse1315 all $(DO_CLEAN)
+package-rpm-opensuse: $(SOURCE_DIST_FILE)
+	$(gen_verbose) $(MAKE) -C RPMS/Fedora $(VARS) RPM_OS=suse all $(DO_CLEAN)
 
 package-windows: $(SOURCE_DIST_FILE)
 	$(gen_verbose) $(MAKE) -C windows $(VARS) all $(DO_CLEAN)

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -35,12 +35,12 @@ all: packages
 
 .PHONY: packages package-deb \
 	package-rpm package-rpm-fedora \
-	package-rpm-opensuse package-rpm-suse \
+	package-rpm-opensuse package-rpm-suse\
 	package-rpm-rhel6 package-rpm-rhel7 \
 	package-windows package-standalone-macosx \
 	package-standalone-linux-x86_64 \
 	package-standalone-freebsd-x86_64 \
-	package-generic-unix
+	package-generic-unix 
 
 PACKAGES_DIR ?= ../PACKAGES
 SOURCE_DIST_FILE ?= $(wildcard $(PACKAGES_DIR)/rabbitmq-server-*.tar.xz)
@@ -74,6 +74,9 @@ packages: package-deb package-rpm package-windows package-generic-unix
 package-deb: $(SOURCE_DIST_FILE)
 	$(gen_verbose) $(MAKE) -C debs/Debian $(VARS) all $(DO_CLEAN)
 
+package-rpm-opensuse package-rpm-suse: package-rpm-opensuse1012 package-rpm-opensuse1315 
+	@:
+
 package-rpm: package-rpm-rhel6 package-rpm-rhel7 package-rpm-opensuse
 	@:
 
@@ -86,8 +89,11 @@ package-rpm-rhel6: $(SOURCE_DIST_FILE)
 package-rpm-rhel7: $(SOURCE_DIST_FILE)
 	$(gen_verbose) $(MAKE) -C RPMS/Fedora $(VARS) RPM_OS=rhel7 all $(DO_CLEAN)
 
-package-rpm-opensuse package-rpm-suse: $(SOURCE_DIST_FILE)
-	$(gen_verbose) $(MAKE) -C RPMS/Fedora $(VARS) RPM_OS=suse all $(DO_CLEAN)
+package-rpm-opensuse1012: $(SOURCE_DIST_FILE)
+	$(gen_verbose) $(MAKE) -C RPMS/Fedora $(VARS) RPM_OS=suse1012 all $(DO_CLEAN)
+
+package-rpm-opensuse1315: $(SOURCE_DIST_FILE)
+	$(gen_verbose) $(MAKE) -C RPMS/Fedora $(VARS) RPM_OS=suse1315 all $(DO_CLEAN)
 
 package-windows: $(SOURCE_DIST_FILE)
 	$(gen_verbose) $(MAKE) -C windows $(VARS) all $(DO_CLEAN)

--- a/packaging/RPMS/Fedora/Makefile
+++ b/packaging/RPMS/Fedora/Makefile
@@ -28,10 +28,16 @@ DEFINES = --define 'upstream_version $(VERSION)' \
 
 RPM_OS ?= fedora
 
-ifeq "$(RPM_OS)" "suse"
+ifeq "$(RPM_OS)" "suse1012"
 FUNCTION_LIBRARY=
 REQUIRES=/sbin/chkconfig /sbin/service
-OS_DEFINES=--define '_unitdir /usr/lib/systemd/system' --define 'dist .suse' --define 'suse_version 1315'
+OS_DEFINES=--define '_initrddir /etc/init.d' --define 'dist .suse1012' --define 'suse_version 1012'
+SPEC_DEFINES=--define 'group_tag Productivity/Networking/Other'
+START_PROG=startproc
+else ifeq "$(RPM_OS)" "suse1315"
+FUNCTION_LIBRARY=
+REQUIRES=/sbin/chkconfig /sbin/service
+OS_DEFINES=--define '_unitdir /usr/lib/systemd/system' --define 'dist .suse1315' --define 'suse_version 1315'
 SPEC_DEFINES=--define 'group_tag Productivity/Networking/Other'
 START_PROG=startproc
 else

--- a/packaging/RPMS/Fedora/Makefile
+++ b/packaging/RPMS/Fedora/Makefile
@@ -31,13 +31,13 @@ RPM_OS ?= fedora
 ifeq "$(RPM_OS)" "suse1012"
 FUNCTION_LIBRARY=
 REQUIRES=/sbin/chkconfig /sbin/service
-OS_DEFINES=--define '_initrddir /etc/init.d' --define 'dist .suse1012' --define 'suse_version 1012'
+OS_DEFINES=--define '_initrddir /etc/init.d' --define 'dist .suse_1012' --define 'suse_version 1012'
 SPEC_DEFINES=--define 'group_tag Productivity/Networking/Other'
 START_PROG=startproc
 else ifeq "$(RPM_OS)" "suse1315"
 FUNCTION_LIBRARY=
 REQUIRES=/sbin/chkconfig /sbin/service
-OS_DEFINES=--define '_unitdir /usr/lib/systemd/system' --define 'dist .suse1315' --define 'suse_version 1315'
+OS_DEFINES=--define '_unitdir /usr/lib/systemd/system' --define 'dist .suse' --define 'suse_version 1315'
 SPEC_DEFINES=--define 'group_tag Productivity/Networking/Other'
 START_PROG=startproc
 else

--- a/packaging/RPMS/Fedora/Makefile
+++ b/packaging/RPMS/Fedora/Makefile
@@ -34,7 +34,7 @@ REQUIRES=/sbin/chkconfig /sbin/service
 OS_DEFINES=--define '_initrddir /etc/init.d' --define 'dist .suse_1012' --define 'suse_version 1012'
 SPEC_DEFINES=--define 'group_tag Productivity/Networking/Other'
 START_PROG=startproc
-else ifeq "$(RPM_OS)" "suse1315"
+else ifeq "$(RPM_OS)" "suse"
 FUNCTION_LIBRARY=
 REQUIRES=/sbin/chkconfig /sbin/service
 OS_DEFINES=--define '_unitdir /usr/lib/systemd/system' --define 'dist .suse' --define 'suse_version 1315'

--- a/packaging/RPMS/Fedora/rabbitmq-server.spec
+++ b/packaging/RPMS/Fedora/rabbitmq-server.spec
@@ -15,7 +15,7 @@ URL: http://www.rabbitmq.com/
 BuildArch: noarch
 BuildRequires: erlang >= %{erlang_minver}, python-simplejson, xmlto, libxslt, gzip, sed, zip, rsync
 
-%if 0%{?fedora} || 0%{?rhel} >= 7 || 0%{?suse_version}
+%if 0%{?fedora} || 0%{?rhel} >= 7 || 0%{?suse_version} >= 1315
 BuildRequires:  systemd
 %endif
 
@@ -23,7 +23,7 @@ Requires: erlang >= %{erlang_minver}, logrotate, socat
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-%{_arch}-root
 Summary: The RabbitMQ server
 
-%if 0%{?fedora} || 0%{?rhel} >= 7 || 0%{?suse_version}
+%if 0%{?fedora} || 0%{?rhel} >= 7 || 0%{?suse_version} >= 1315
 Requires(pre): systemd
 Requires(post): systemd
 Requires(preun): systemd
@@ -63,7 +63,7 @@ mkdir -p %{buildroot}%{_localstatedir}/log/rabbitmq
 
 #Copy all necessary lib files etc.
 
-%if 0%{?fedora} || 0%{?rhel} >= 7 || 0%{?suse_version}
+%if 0%{?fedora} || 0%{?rhel} >= 7 || 0%{?suse_version} >= 1315
 install -p -D -m 0644 %{S:3} %{buildroot}%{_unitdir}/%{name}.service
 %else
 install -p -D -m 0755 %{S:1} %{buildroot}%{_initrddir}/rabbitmq-server
@@ -86,7 +86,7 @@ for script in rabbitmq-server rabbitmq-plugins; do \
 	 %{buildroot}%{_sbindir}/$script; \
 done
 
-%if 0%{?fedora} > 14 || 0%{?rhel} >= 7 || 0%{?suse_version}
+%if 0%{?fedora} > 14 || 0%{?rhel} >= 7 || 0%{?suse_version} >= 1315
 install -D -p -m 0644 %{SOURCE4} %{buildroot}%{_prefix}/lib/tmpfiles.d/%{name}.conf
 %endif
 
@@ -118,7 +118,7 @@ fi
 
 %post
 
-%if 0%{?fedora} || 0%{?rhel} >= 7 || 0%{?suse_version}
+%if 0%{?fedora} || 0%{?rhel} >= 7 || 0%{?suse_version} >= 1315
 # %%systemd_post %%{name}.service
 # manual expansion of systemd_post as this doesn't appear to
 # expand correctly on debian machines
@@ -139,7 +139,7 @@ chmod -R o-rwx,g-w %{_localstatedir}/lib/rabbitmq/mnesia
 %preun
 if [ $1 = 0 ]; then
   #Complete uninstall
-%if 0%{?fedora} || 0%{?rhel} >= 7 || 0%{?suse_version}
+%if 0%{?fedora} || 0%{?rhel} >= 7 || 0%{?suse_version} >= 1315
   systemctl stop rabbitmq-server
 %else
   /sbin/service rabbitmq-server stop
@@ -157,7 +157,7 @@ for ext in rel script boot ; do
 done
 
 %postun
-%if 0%{?fedora} || 0%{?rhel} >= 7 || 0%{?suse_version}
+%if 0%{?fedora} || 0%{?rhel} >= 7 || 0%{?suse_version} >= 1315
 # %%systemd_postun_with_restart %%{name}.service
 # manual expansion of systemd_postun_with_restart as this doesn't appear to
 # expand correctly on debian machines
@@ -171,7 +171,7 @@ if [ $1 -gt 1 ]; then
 fi
 %endif
 
-%if 0%{?fedora} > 17 || 0%{?rhel} >= 7 || 0%{?suse_version}
+%if 0%{?fedora} > 17 || 0%{?rhel} >= 7 || 0%{?suse_version} >= 1315
 # For prior versions older than this, do a conversion
 # from sysv to systemd
 %triggerun -- %{name} < 3.6.5


### PR DESCRIPTION
Fixes https://github.com/rabbitmq/rabbitmq-server-release/issues/41

1 - support with systemd 
2 - no systemd ( for old versions )

**with Systemd**
```
rabbitmq-server-3.6.12.rc1+dirty-1.suse1315.noarch.rpm
rabbitmq-server-3.6.12.rc1+dirty-1.suse1315.src.rpm
```
Tested on:

```
cat /etc/*release
NAME=openSUSE
VERSION="13.2 (Harlequin)"
VERSION_ID="13.2"
PRETTY_NAME="openSUSE 13.2 (Harlequin) (x86_64)"
ID=opensuse
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:opensuse:opensuse:13.2"
BUG_REPORT_URL="https://bugs.opensuse.org"
HOME_URL="https://opensuse.org/"
ID_LIKE="suse"
openSUSE 13.2 (x86_64)
VERSION = 13.2



sudo systemctl status rabbitmq-server
rabbitmq-server.service - RabbitMQ broker
   Loaded: loaded (/usr/lib/systemd/system/rabbitmq-server.service; disabled)
   Active: active (running) since Tue 2017-08-29 14:58:12 CEST; 1h 53min ago
 Main PID: 27845 (beam)
   Status: "Initialized"
   CGroup: /system.slice/rabbitmq-server.service
           ├─27845 /usr/lib64/erlang/erts-6.1/bin/beam -W w -A 64 -P 1048576 -t 5000000 -stbt db -zdbbl 12...
           ├─28126 inet_gethost 4
           └─28127 inet_gethost 4

Aug 29 14:58:01 vagrant-openSUSE-Harlequin rabbitmq-server[27845]: RabbitMQ 3.6.12.rc1+dirty. Copyright ...c.
Aug 29 14:58:01 vagrant-openSUSE-Harlequin rabbitmq-server[27845]: ##  ##      Licensed under the MPL.  ...m/
Aug 29 14:58:01 vagrant-openSUSE-Harlequin rabbitmq-server[27845]: ##  ##
Aug 29 14:58:01 vagrant-openSUSE-Harlequin rabbitmq-server[27845]: ##########  Logs: /var/log/rabbitmq/r...og
Aug 29 14:58:01 vagrant-openSUSE-Harlequin rabbitmq-server[27845]: ######  ##        /var/log/rabbitmq/r...og
Aug 29 14:58:01 vagrant-openSUSE-Harlequin rabbitmq-server[27845]: ##########
Aug 29 14:58:01 vagrant-openSUSE-Harlequin rabbitmq-server[27845]: Starting broker...
Aug 29 14:58:12 vagrant-openSUSE-Harlequin rabbitmq-server[27845]: systemd unit for activation check: "r...e"
Aug 29 14:58:12 vagrant-openSUSE-Harlequin systemd[1]: Started RabbitMQ broker.
Aug 29 14:58:12 vagrant-openSUSE-Harlequin rabbitmq-server[

```

**no systemd**

```
rabbitmq-server-3.6.12.rc1+dirty-1.suse1012.noarch.rpm
rabbitmq-server-3.6.12.rc1+dirty-1.suse1012.src.rpm
```
Tested  on:
```
gabriele@linux-er46:/tmp> cat /etc/*release
openSUSE 11.4 (x86_64)
VERSION = 11.4
CODENAME = Celadon


sudo rpm -i rabbitmq-server-3.6.12.rc1+dirty-1.suse1012.noarch.rpm

sudo /etc/rc.d/rabbitmq-server start
Starting rabbitmq-server: SUCCESS
rabbitmq-server.


```
