### PR TITLE
Use runuser in non-su-compatible mode

### DIFF
--- a/scripts/rabbitmq-script-wrapper
+++ b/scripts/rabbitmq-script-wrapper
@@ -77,7 +77,18 @@ exec_script_as_rabbitmq() {
 exec_script_as_root() {
   if [ -x /sbin/runuser ]
   then
-    exec /sbin/runuser -u rabbitmq -- "/usr/lib/rabbitmq/bin/$SCRIPT" "$@"
+    # TODO:
+    # At some point all of the RabbitMQ supported distributions will be using
+    # the util-linux version of /sbin/runuser, as it has been removed from GNU
+    # coreutils as of 2012. At that point the first clause of the following
+    # if statement can become the only statement used and the if/then
+    # removed
+    if /sbin/runuser --version | grep -qF util-linux
+    then
+        exec /sbin/runuser -u rabbitmq -- "/usr/lib/rabbitmq/bin/$SCRIPT" "$@"
+    else
+        exec /sbin/runuser -s /bin/sh -- rabbitmq "/usr/lib/rabbitmq/bin/$SCRIPT" "$@"
+    fi
   elif [ -x /bin/su ]
   then
     exec /bin/su -s /bin/sh rabbitmq -- "/usr/lib/rabbitmq/bin/$SCRIPT" "$@"

--- a/scripts/rabbitmq-script-wrapper
+++ b/scripts/rabbitmq-script-wrapper
@@ -15,12 +15,6 @@
 ##  Copyright (c) 2007-2015 Pivotal Software, Inc.  All rights reserved.
 ##
 
-for arg in "$@" ; do
-    # Wrap each arg in single quotes and wrap single quotes in double quotes, so that they're passed through cleanly.
-    arg=`printf %s "$arg" | sed -e "s#'#'\"'\"'#g"`
-    CMDLINE="${CMDLINE} '${arg}'"
-done
-
 SCRIPT="$(basename "$0")"
 RABBITMQ_ENV=/usr/lib/rabbitmq/bin/rabbitmq-env
 RABBITMQ_SCRIPTS_DIR="$(dirname "$RABBITMQ_ENV")"
@@ -38,7 +32,7 @@ main() {
     exec_script_as_rabbitmq "$@"
   elif current_user_is_root
   then
-    exec_script_as_root
+    exec_script_as_root "$@"
   else
     run_script_help_and_fail
   fi
@@ -83,10 +77,10 @@ exec_script_as_rabbitmq() {
 exec_script_as_root() {
   if [ -x /sbin/runuser ]
   then
-    exec /sbin/runuser -s /bin/sh -c "/usr/lib/rabbitmq/bin/$SCRIPT $CMDLINE" rabbitmq
+    exec /sbin/runuser -u rabbitmq -- "/usr/lib/rabbitmq/bin/$SCRIPT" "$@"
   elif [ -x /bin/su ]
   then
-    exec /bin/su rabbitmq -s /bin/sh -c "/usr/lib/rabbitmq/bin/$SCRIPT $CMDLINE"
+    exec /bin/su -s /bin/sh rabbitmq -- "/usr/lib/rabbitmq/bin/$SCRIPT" "$@"
   else
     echo "Please ensure /bin/su or /sbin/runuser exists and can be executed by $USER." 1>&2
     exit 1


### PR DESCRIPTION
Fixes #44 

Inspired by #40 where I didn't have the `runuser` arguments just right, then by ab705f8359fada8cc9ccdc72ff638657956f2d06 and aa84ddcf36b67e0196b5cfa81bb34008bdf70a43.

Also, remove argument quoting which is not necessary as long as original script arguments are passed to `/sbin/runuser` and `/bin/su` as arguments instead of one big string.

Tested using the following scripts -

Save this to `/var/lib/rabbitmq/runuser-test` and make it executable:

```sh
#!/bin/sh
echo subcmd via runuser:
/sbin/runuser -u rabbitmq -- /var/lib/rabbitmq/runuser-subcmd "$@"
echo
echo subcmd via su:
/bin/su -s /bin/sh rabbitmq -- /var/lib/rabbitmq/runuser-subcmd "$@"
```

Save this to `/var/lib/rabbitmq/runuser-subcmd` and make it executable:

```sh
#!/bin/sh
echo "$0"
echo "ID: $(id)"
echo "ARGS: $@"
for ARG in "$@"
do
    echo "ARG: $ARG"
done
```

Example command and output from my CentOS 7 VM:

```
[root@localhost ~]# /var/lib/rabbitmq/runuser-test ARG0 'ARG 1' '"ARG 2"' "ARG 3"                                                                                                                                                                                               
subcmd via runuser:                                                                                                                                                                                                                                                             
/var/lib/rabbitmq/runuser-subcmd                                                                                                                                                                                                                                                
ID: uid=996(rabbitmq) gid=994(rabbitmq) groups=994(rabbitmq) context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023                                                                                                                                                      
ARGS: ARG0 ARG 1 "ARG 2" ARG 3                                                                                                                                                                                                                                                  
ARG: ARG0                                                                                                                                                                                                                                                                       
ARG: ARG 1                                                                                                                                                                                                                                                                      
ARG: "ARG 2"                                                                                                                                                                                                                                                                    
ARG: ARG 3                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                
subcmd via su:                                                                                                                                                                                                                                                                  
/var/lib/rabbitmq/runuser-subcmd                                                                                                                                                                                                                                                
ID: uid=996(rabbitmq) gid=994(rabbitmq) groups=994(rabbitmq) context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
ARGS: ARG0 ARG 1 "ARG 2" ARG 3
ARG: ARG0
ARG: ARG 1
ARG: "ARG 2"
ARG: ARG 3
```