### PR TITLE
packaging/debs/apt-repository/distributions: Add more valid `Architectures`

### DIFF
--- a/packaging/debs/apt-repository/distributions
+++ b/packaging/debs/apt-repository/distributions
@@ -2,6 +2,6 @@ Origin: RabbitMQ
 Label: RabbitMQ Repository for Debian / Ubuntu etc
 Suite: testing
 Codename: kitten
-Architectures: AVR32 alpha amd64 arm arm64 armeb armel armhf avr32 hppa hurd-i386 i386 ia64 kfreebsd-amd64 kfreebsd-i386 m32 m32r m68k mips mips64 mips64el mips64r6 mips64r6el mipsel mipsr6 mipsr6el netbsd-alpha netbsd-i386 nios2 or1k powerpc powerpcel ppc64 ppc64el s390 s390x sh sh3 sh3eb sh4 sh4eb sparc sparc64 tilegx source
+Architectures: alpha amd64 arm arm64 armeb armel armhf avr32 hppa hurd-i386 i386 ia64 kfreebsd-amd64 kfreebsd-i386 m32 m32r m68k mips mips64 mips64el mips64r6 mips64r6el mipsel mipsr6 mipsr6el netbsd-alpha netbsd-i386 nios2 or1k powerpc powerpcel ppc64 ppc64el s390 s390x sh sh3 sh3eb sh4 sh4eb sparc sparc64 tilegx source
 Components: main
 Description: RabbitMQ Repository for Debian / Ubuntu etc

--- a/packaging/debs/apt-repository/distributions
+++ b/packaging/debs/apt-repository/distributions
@@ -2,6 +2,6 @@ Origin: RabbitMQ
 Label: RabbitMQ Repository for Debian / Ubuntu etc
 Suite: testing
 Codename: kitten
-Architectures: AVR32 alpha amd64 arm armel armhf arm64 hppa hurd-i386 i386 ia64 kfreebsd-amd64 kfreebsd-i386 m32 m68k mips mipsel netbsd-alpha netbsd-i386 powerpc s390 s390x sh sparc source
+Architectures: AVR32 alpha amd64 arm arm64 armeb armel armhf avr32 hppa hurd-i386 i386 ia64 kfreebsd-amd64 kfreebsd-i386 m32 m32r m68k mips mips64 mips64el mips64r6 mips64r6el mipsel mipsr6 mipsr6el netbsd-alpha netbsd-i386 nios2 or1k powerpc powerpcel ppc64 ppc64el s390 s390x sh sh3 sh3eb sh4 sh4eb sparc sparc64 tilegx source
 Components: main
 Description: RabbitMQ Repository for Debian / Ubuntu etc


### PR DESCRIPTION
See the first column of https://sources.debian.net/src/dpkg/stretch/data/cputable/ for where these values were sourced from.

Realistically, I'm mostly interested in `ppc64el` being added here, but figured while I was at it, I might as well look for an upstream `dpkg` source-of-truth table to get more valid values.

I'm also happy to update this to be less aggressive if this fuller list is undesirable. :innocent:

(or to send this request/PR elsewhere if there's somewhere more appropriate for it to be filed :heart:)