### PR TITLE
packaging: Set log directory permissions on fresh install

### DIFF
--- a/packaging/debs/Debian/debian/postinst
+++ b/packaging/debs/Debian/debian/postinst
@@ -42,6 +42,22 @@ chmod -R o-rwx,g-w /var/lib/rabbitmq/mnesia
 
 case "$1" in
     configure)
+        if test -z "$2"; then
+            # This is a fresh install of the package.
+
+            # On a fresh install, we want to limit permissions on the
+            # log directory to the owner and the group. Others won't
+            # have any access to log files: this is in case sensitive
+            # data are accidentally logged (like process crash data).
+            chmod 750 /var/log/rabbitmq
+        else
+            # The package was already configured: it's an upgrade over
+            # a previously installed version, or it's an install over
+            # a non-purged version (i.e. deinstalled but configuration
+            # files and data are still there).
+            true
+        fi
+
         if [ -n "$ZSH_VERSION" ]; then
             echo "Z Shell detected.
 to enable rabbitmqctl autocompletion add the following to your .zshrc file:


### PR DESCRIPTION
On a fresh install, we want to limit access to the log directory to the owner and group. This is in case sensitive data are logged.

We don't enforce the permissions on upgrade because:

1. We don't want to break exising installs by reducing permissions.
2. The admin may want to setup different permissions.

References rabbitmq/rabbitmq-management#474.
[#150970897]