### PR TITLE
Add optional Restart and RestartSec configuration

### DIFF
--- a/packaging/RPMS/Fedora/rabbitmq-server.service
+++ b/packaging/RPMS/Fedora/rabbitmq-server.service
@@ -6,12 +6,20 @@ After=syslog.target network.target
 Type=notify
 User=rabbitmq
 Group=rabbitmq
+NotifyAccess=all
+TimeoutStartSec=3600
+# Note:
+# You *may* wish to add the following to automatically restart RabbitMQ
+# in the event of a failure. systemd service restarts are not a
+# replacement for service monitoring. Please see
+# http://www.rabbitmq.com/monitoring.html
+#
+# Restart=on-failure # https://www.freedesktop.org/software/systemd/man/systemd.service.html#Restart=
+# RestartSec=10      # https://www.freedesktop.org/software/systemd/man/systemd.service.html#RestartSec=
 WorkingDirectory=/var/lib/rabbitmq
 ExecStart=/usr/sbin/rabbitmq-server
 ExecStop=/usr/sbin/rabbitmqctl stop
 ExecStop=/bin/sh -c "while ps -p $MAINPID >/dev/null 2>&1; do sleep 1; done"
-NotifyAccess=all
-TimeoutStartSec=3600
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/RPMS/Fedora/rabbitmq-server.service
+++ b/packaging/RPMS/Fedora/rabbitmq-server.service
@@ -8,14 +8,12 @@ User=rabbitmq
 Group=rabbitmq
 NotifyAccess=all
 TimeoutStartSec=3600
-# Note:
-# You *may* wish to add the following to automatically restart RabbitMQ
+# The following setting will automatically restart RabbitMQ
 # in the event of a failure. systemd service restarts are not a
 # replacement for service monitoring. Please see
 # http://www.rabbitmq.com/monitoring.html
-#
-# Restart=on-failure # https://www.freedesktop.org/software/systemd/man/systemd.service.html#Restart=
-# RestartSec=10      # https://www.freedesktop.org/software/systemd/man/systemd.service.html#RestartSec=
+Restart=on-failure # https://www.freedesktop.org/software/systemd/man/systemd.service.html#Restart=
+RestartSec=10      # https://www.freedesktop.org/software/systemd/man/systemd.service.html#RestartSec=
 WorkingDirectory=/var/lib/rabbitmq
 ExecStart=/usr/sbin/rabbitmq-server
 ExecStop=/usr/sbin/rabbitmqctl stop

--- a/packaging/debs/Debian/debian/rabbitmq-server.service
+++ b/packaging/debs/Debian/debian/rabbitmq-server.service
@@ -10,14 +10,12 @@ User=rabbitmq
 Group=rabbitmq
 NotifyAccess=all
 TimeoutStartSec=3600
-# Note:
-# You *may* wish to add the following to automatically restart RabbitMQ
+# The following setting will automatically restart RabbitMQ
 # in the event of a failure. systemd service restarts are not a
 # replacement for service monitoring. Please see
 # http://www.rabbitmq.com/monitoring.html
-#
-# Restart=on-failure # https://www.freedesktop.org/software/systemd/man/systemd.service.html#Restart=
-# RestartSec=10      # https://www.freedesktop.org/software/systemd/man/systemd.service.html#RestartSec=
+Restart=on-failure # https://www.freedesktop.org/software/systemd/man/systemd.service.html#Restart=
+RestartSec=10      # https://www.freedesktop.org/software/systemd/man/systemd.service.html#RestartSec=
 WorkingDirectory=/var/lib/rabbitmq
 ExecStart=/usr/lib/rabbitmq/bin/rabbitmq-server
 ExecStop=/usr/lib/rabbitmq/bin/rabbitmqctl stop

--- a/packaging/debs/Debian/debian/rabbitmq-server.service
+++ b/packaging/debs/Debian/debian/rabbitmq-server.service
@@ -10,6 +10,14 @@ User=rabbitmq
 Group=rabbitmq
 NotifyAccess=all
 TimeoutStartSec=3600
+# Note:
+# You *may* wish to add the following to automatically restart RabbitMQ
+# in the event of a failure. systemd service restarts are not a
+# replacement for service monitoring. Please see
+# http://www.rabbitmq.com/monitoring.html
+#
+# Restart=on-failure # https://www.freedesktop.org/software/systemd/man/systemd.service.html#Restart=
+# RestartSec=10      # https://www.freedesktop.org/software/systemd/man/systemd.service.html#RestartSec=
 WorkingDirectory=/var/lib/rabbitmq
 ExecStart=/usr/lib/rabbitmq/bin/rabbitmq-server
 ExecStop=/usr/lib/rabbitmq/bin/rabbitmqctl stop


### PR DESCRIPTION
See rabbitmq/rabbitmq-server#1359

This gives guidances for those users who wish to automatically restart RabbitMQ in the event of a failure. Tested by using the `Restart=on-failure` setting, then running `rabbitmqctl eval "erlang:halt(abort)."`