### PR TITLE
Set the shell field of the user rabbitmq to /sbin/nologin for security

### DIFF
--- a/packaging/RPMS/Fedora/rabbitmq-server.spec
+++ b/packaging/RPMS/Fedora/rabbitmq-server.spec
@@ -124,7 +124,7 @@ fi
 
 # create rabbitmq user
 if ! getent passwd rabbitmq >/dev/null; then
-        useradd -r -g rabbitmq -d %{_localstatedir}/lib/rabbitmq rabbitmq \
+        useradd -r -g rabbitmq -d %{_localstatedir}/lib/rabbitmq -s /sbin/nologin rabbitmq \
             -c "RabbitMQ messaging server"
 fi
 


### PR DESCRIPTION
By default Red Hat 7 sets the password field for these accounts to an invalid string, but it is also recommended that the shell field in the password file be set to /sbin/nologin . This prevents the account from potentially being used to run any commands.