### PR TITLE
Set min version of systemd to 218

### DIFF
--- a/packaging/RPMS/Fedora/rabbitmq-server.spec
+++ b/packaging/RPMS/Fedora/rabbitmq-server.spec
@@ -24,9 +24,9 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-%{_arch}-root
 Summary: The RabbitMQ server
 
 %if 0%{?fedora} || 0%{?rhel} >= 7 || 0%{?suse_version} >= 1315
-Requires(pre): systemd
-Requires(post): systemd
-Requires(preun): systemd
+Requires(pre): systemd >= 218
+Requires(post): systemd >= 218
+Requires(preun): systemd >= 218
 %else
 Requires(post): %%REQUIRES%%
 Requires(pre): %%REQUIRES%%


### PR DESCRIPTION
The Systemd daemon before version 218 has issue when `type` is `notify` and service status is updated via unix-socket file.
Issue #54 