### PR TITLE
Bundle Elixir dependencies and fix offline build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,10 +123,13 @@ $(SOURCE_DIST): $(ERLANG_MK_RECURSIVE_DEPS_LIST)
 	$(verbose) echo "$(PROJECT) $$(git rev-parse HEAD) $$(git describe --tags --exact-match 2>/dev/null || git symbolic-ref -q --short HEAD)" >> $@/git-revisions.txt
 	$(verbose) cat packaging/common/LICENSE.head > $@/LICENSE
 	$(verbose) mkdir -p $@/deps/licensing
-	$(verbose) for dep in $$(cat $(ERLANG_MK_RECURSIVE_DEPS_LIST) | LC_COLLATE=C sort); do \
+	$(verbose) set -e; for dep in $$(cat $(ERLANG_MK_RECURSIVE_DEPS_LIST) | LC_COLLATE=C sort); do \
 		$(RSYNC) $(RSYNC_FLAGS) \
 		 $$dep \
 		 $@/deps; \
+		rm -f \
+		 $@/deps/rabbit_common/rebar.config \
+		 $@/deps/rabbit_common/rebar.lock; \
 		if test -f $@/deps/$$(basename $$dep)/erlang.mk && \
 		   test "$$(wc -l $@/deps/$$(basename $$dep)/erlang.mk | awk '{print $$1;}')" = "1" && \
 		   grep -qs -E "^[[:blank:]]*include[[:blank:]]+(erlang\.mk|.*/erlang\.mk)$$" $@/deps/$$(basename $$dep)/erlang.mk; then \
@@ -135,12 +138,21 @@ $(SOURCE_DIST): $(ERLANG_MK_RECURSIVE_DEPS_LIST)
 		sed -E -i.bak "s|^[[:blank:]]*include[[:blank:]]+\.\./.*erlang.mk$$|include ../../erlang.mk|" \
 		 $@/deps/$$(basename $$dep)/Makefile && \
 		rm $@/deps/$$(basename $$dep)/Makefile.bak; \
+		mix_exs=$@/deps/$$(basename $$dep)/mix.exs; \
+		if test -f $$mix_exs; then \
+			(cd $$(dirname "$$mix_exs") && \
+			 env DEPS_DIR=$@/deps HOME=$@/deps MIX_ENV=prod FILL_HEX_CACHE=yes mix deps.get && \
+			 cp $(DEPS_DIR)/rabbit_common/mk/rabbitmq-mix.mk . && \
+			 rm -rf _build deps); \
+		fi; \
 		if test -f "$$dep/license_info"; then \
 			cp "$$dep/license_info" "$@/deps/licensing/license_info_$$(basename "$$dep")"; \
 			cat "$$dep/license_info" >> $@/LICENSE; \
 		fi; \
 		find "$$dep" -maxdepth 1 -name 'LICENSE-*' -exec cp '{}' $@/deps/licensing \; ; \
-		(cd $$dep; echo "$$(basename "$$dep") $$(git rev-parse HEAD) $$(git describe --tags --exact-match 2>/dev/null || git symbolic-ref -q --short HEAD)") >> $@/git-revisions.txt; \
+		(cd $$dep; \
+		 echo "$$(basename "$$dep") $$(git rev-parse HEAD) $$(git describe --tags --exact-match 2>/dev/null || git symbolic-ref -q --short HEAD)") \
+		 >> $@/git-revisions.txt; \
 	done
 	$(verbose) cat packaging/common/LICENSE.tail >> $@/LICENSE
 	$(verbose) find $@/deps/licensing -name 'LICENSE-*' -exec cp '{}' $@ \;

--- a/packaging/RPMS/Fedora/rabbitmq-server.spec
+++ b/packaging/RPMS/Fedora/rabbitmq-server.spec
@@ -234,6 +234,9 @@ systemctl try-restart %{name}.service >/dev/null 2>&1 || :
 rm -rf %{buildroot}
 
 %changelog
+* Wed Nov 29 2017 info@rabbitmq.com 3.7.0-1
+- New upstream release.
+
 * Thu Nov 16 2017 info@rabbitmq.com 3.7.0~rc.2-1
 - New upstream release.
 

--- a/packaging/debs/Debian/debian/changelog
+++ b/packaging/debs/Debian/debian/changelog
@@ -1,3 +1,9 @@
+rabbitmq-server (3.7.0-1) unstable; urgency=low
+
+  * New Upstream Release.
+
+ -- RabbitMQ Team <info@rabbitmq.com>  Wed, 29 Nov 2017 16:52:39 +0000
+
 rabbitmq-server (3.7.0~rc.2-1) unstable; urgency=low
 
   * New Upstream Release.

--- a/packaging/windows-exe/rabbitmq_nsi.in
+++ b/packaging/windows-exe/rabbitmq_nsi.in
@@ -270,16 +270,11 @@ Function findErlang
     abort:
     Abort
   ${Else}
-    ${VersionCompare} $2 "5.7.4" $0
-    ${VersionCompare} $2 "5.8.1" $1
+    ${VersionCompare} $2 "8.3" $0
 
     ${If} $0 = 2
       MessageBox MB_OK|MB_ICONEXCLAMATION "Your installed version of Erlang ($2) is too old. Please install a more recent version."
       Abort
-    ${ElseIf} $1 = 2
-      MessageBox MB_YESNO|MB_ICONEXCLAMATION "Your installed version of Erlang ($2) is comparatively old.$\nFor best results, please install a newer version.$\nDo you wish to continue?" IDYES no_abort
-      Abort
-      no_abort:
     ${EndIf}
 
     ReadRegStr $0 HKLM "Software\Ericsson\Erlang\$2" ""

--- a/rabbitmq-components.mk
+++ b/rabbitmq-components.mk
@@ -115,7 +115,7 @@ dep_cowlib = hex 2.0.0
 dep_jsx = hex 2.8.2
 dep_lager = hex 3.5.1
 dep_ranch = hex 1.4.0
-dep_ranch_proxy_protocol = hex 1.4.2
+dep_ranch_proxy_protocol = hex 1.4.4
 dep_recon = hex 2.3.2
 
 dep_sockjs = git https://github.com/rabbitmq/sockjs-erlang.git 405990ea62353d98d36dbf5e1e64942d9b0a1daf
@@ -326,11 +326,16 @@ endif
 
 UPSTREAM_RMQ_COMPONENTS_MK = $(DEPS_DIR)/rabbit_common/mk/rabbitmq-components.mk
 
+ifeq ($(PROJECT),rabbit_common)
+check-rabbitmq-components.mk:
+	@:
+else
 check-rabbitmq-components.mk:
 	$(verbose) cmp -s rabbitmq-components.mk \
 		$(UPSTREAM_RMQ_COMPONENTS_MK) || \
 		(echo "error: rabbitmq-components.mk must be updated!" 1>&2; \
 		  false)
+endif
 
 ifeq ($(PROJECT),rabbit_common)
 rabbitmq-components-mk:


### PR DESCRIPTION
References rabbitmq/rabbitmq-server-release#61.

Depends on rabbitmq/rabbitmq-common#244.
Depends on rabbitmq/rabbitmq-cli#231.