### PR TITLE
OCF RA: Avoid promoting nodes with same start time as master

### DIFF
--- a/scripts/rabbitmq-server-ha.ocf
+++ b/scripts/rabbitmq-server-ha.ocf
@@ -1608,6 +1608,11 @@ get_monitor() {
             ocf_log info "${LH} comparing us (start time: $our_start_time, score: $new_score) with $node (start time: $node_start_time, score: $node_score)"
             if [ $node_start_time -ne 0 -a $node_score -ne 0 -a $node_start_time -lt $our_start_time ]; then
                 new_score=$((node_score - 10 < new_score ? node_score - 10 : new_score ))
+            elif [ $node_start_time -ne 0 -a $node_score -ne 0 -a $node_start_time -eq $our_start_time ]
+                # Do not get promoted if the other node is already master and we have the same start time
+                if is_master $node; then
+                    new_score=$((node_score - 10 < new_score ? node_score - 10 : new_score ))
+                fi
             fi
         done
     fi


### PR DESCRIPTION
It may happen that two nodes have the same start time, and one of these
is the master. When this happens, the node actually gets the same score
as the master and can get promoted. There's no reason to avoid being
stable here, so let's keep the same master in that scenario.