### PR TITLE
OCF RA: Fix various issues with start notification handler

### DIFF
--- a/scripts/rabbitmq-server-ha.ocf
+++ b/scripts/rabbitmq-server-ha.ocf
@@ -2217,7 +2217,6 @@ action_notify() {
                       rc2=$?
                       update_rabbit_start_time_if_rc $rc2
                     fi
-                    ocf_log info "${LH} post-start end."
                     if [ -s "${OCF_RESKEY_definitions_dump_file}" ] ; then
                         ocf_log info "File ${OCF_RESKEY_definitions_dump_file} exists"
                         ocf_run curl --silent --show-error --request POST --user $OCF_RESKEY_admin_user:$OCF_RESKEY_admin_password $OCF_RESKEY_host_ip:15672/api/definitions --header "Content-Type:application/json" --data @$OCF_RESKEY_definitions_dump_file
@@ -2234,6 +2233,7 @@ action_notify() {
                         return $OCF_ERR_GENERIC
                     fi
                 fi
+                ocf_log info "${LH} post-start end."
                 ;;
             stop)
                 # if rabbitmq-server stops on any another node, we should remove it from cluster (as ordinary operation)

--- a/scripts/rabbitmq-server-ha.ocf
+++ b/scripts/rabbitmq-server-ha.ocf
@@ -2185,7 +2185,7 @@ action_notify() {
                 local nodes_list="${OCF_RESKEY_CRM_meta_notify_start_uname} ${OCF_RESKEY_CRM_meta_notify_active_uname}"
                 # Do nothing, if the list of nodes being started or running reported empty
                 # Delegate recovery, if needed, to the "running out of the cluster" monitor's logic
-                if [ -z "${nodes_list}" ] ; then
+                if [ -z "${OCF_RESKEY_CRM_meta_notify_start_uname}" -a -z "${OCF_RESKEY_CRM_meta_notify_active_uname}" ] ; then
                   ocf_log warn "${LH} I'm a last man standing and I must survive!"
                   ocf_log info "${LH} post-start end."
                   return $OCF_SUCCESS

--- a/scripts/rabbitmq-server-ha.ocf
+++ b/scripts/rabbitmq-server-ha.ocf
@@ -2182,7 +2182,6 @@ action_notify() {
                 ;;
             start)
                 ocf_log info "${LH} post-start begin."
-                local nodes_list="${OCF_RESKEY_CRM_meta_notify_start_uname} ${OCF_RESKEY_CRM_meta_notify_active_uname}"
                 # Do nothing, if the list of nodes being started or running reported empty
                 # Delegate recovery, if needed, to the "running out of the cluster" monitor's logic
                 if [ -z "${OCF_RESKEY_CRM_meta_notify_start_uname}" -a -z "${OCF_RESKEY_CRM_meta_notify_active_uname}" ] ; then
@@ -2191,7 +2190,7 @@ action_notify() {
                   return $OCF_SUCCESS
                 fi
                 # check did this event from this host
-                my_host "${nodes_list}"
+                my_host "${OCF_RESKEY_CRM_meta_notify_start_uname}"
                 rc=$?
                 # Do nothing, if there is no master reported
                 # Delegate recovery, if needed, to the "running out of the cluster" monitor's logic


### PR DESCRIPTION
**OCF RA: Fix test for no node in start notification handler**

If there's nothing starting and nothing active, then we do a -z " ",
which doesn't have the same result as -z "". Instead, just test for
emptiness for each set of nodes.

**OCF RA: Do not start rabbitmq if notification of start is not about us**

Right now, every time we get a start notification, all nodes will ensure
the rabbitmq app is started. This makes little sense, as nodes that are
already active don't need to do that.

On top of that, this had the sideeffect of updating the start time for
each of these nodes, which could result in the master moving to another
node.

**OCF RA: Fix logging in start notification handler**

The "post-start end" log message was written too early (some things were
still done afterwards), and not in all cases (it was inside a if
statement).