### PR TITLE
Make adm group owner of /var/log/rabbitmq

### DIFF
--- a/packaging/debs/Debian/debian/postinst
+++ b/packaging/debs/Debian/debian/postinst
@@ -31,7 +31,7 @@ if ! getent passwd rabbitmq >/dev/null; then
 fi
 
 chown -R rabbitmq:rabbitmq /var/lib/rabbitmq
-chown -R rabbitmq:rabbitmq /var/log/rabbitmq
+chown -R rabbitmq:adm /var/log/rabbitmq
 chgrp rabbitmq /etc/rabbitmq 
 chmod 2750 /etc/rabbitmq
 chmod 750 /var/lib/rabbitmq/mnesia


### PR DESCRIPTION
Adm should be group owner of everything in /var/log according to Debian/Ubuntu guidelines. Makes it possible for users in the adm group to read logs without sudo:ing.