### PR TITLE
Make adm the group owner for RabbitMQ log directories.

### DIFF
--- a/packaging/RPMS/Fedora/rabbitmq-server.service
+++ b/packaging/RPMS/Fedora/rabbitmq-server.service
@@ -6,6 +6,7 @@ After=syslog.target network.target
 Type=notify
 User=rabbitmq
 Group=rabbitmq
+UMask=0027
 NotifyAccess=all
 TimeoutStartSec=3600
 # Un-comment this setting if you need to increase RabbitMQ's

--- a/packaging/debs/Debian/debian/postinst
+++ b/packaging/debs/Debian/debian/postinst
@@ -31,7 +31,7 @@ if ! getent passwd rabbitmq >/dev/null; then
 fi
 
 chown -R rabbitmq:rabbitmq /var/lib/rabbitmq
-chown -R rabbitmq:rabbitmq /var/log/rabbitmq
+chown -R rabbitmq:adm /var/log/rabbitmq
 chgrp rabbitmq /etc/rabbitmq 
 chmod 2750 /etc/rabbitmq
 chmod 750 /var/lib/rabbitmq/mnesia

--- a/packaging/debs/Debian/debian/postinst
+++ b/packaging/debs/Debian/debian/postinst
@@ -49,7 +49,7 @@ case "$1" in
             # log directory to the owner and the group. Others won't
             # have any access to log files: this is in case sensitive
             # data are accidentally logged (like process crash data).
-            chmod 750 /var/log/rabbitmq
+            chmod 2750 /var/log/rabbitmq
         else
             # The package was already configured: it's an upgrade over
             # a previously installed version, or it's an install over
@@ -80,5 +80,3 @@ esac
 #DEBHELPER#
 
 exit 0
-
-

--- a/packaging/debs/Debian/debian/rabbitmq-server.service
+++ b/packaging/debs/Debian/debian/rabbitmq-server.service
@@ -8,6 +8,7 @@ Wants=network.target epmd@0.0.0.0.socket
 Type=notify
 User=rabbitmq
 Group=rabbitmq
+UMask=0027
 NotifyAccess=all
 TimeoutStartSec=3600
 # Un-comment this setting if you need to increase RabbitMQ's


### PR DESCRIPTION
Includes and supersedes #69 

Also sets the umask via systemd service file so that files created by RabbitMQ are not world-readable.

Locally tested using RabbitMQ 3.7.0 on Ubuntu 16 by manually setting directory permissions on `/var/log/rabbitmq` and editing the `rabbitmq-server.service` file.

We may wish to consider adding a `umask` call [in the `rabbitmq-server` file](https://github.com/rabbitmq/rabbitmq-server/blob/master/scripts/rabbitmq-server#L23) as well.

[#153734997]