### PR TITLE
Revert "Change to 2750"

### DIFF
--- a/packaging/RPMS/Fedora/rabbitmq-server.spec
+++ b/packaging/RPMS/Fedora/rabbitmq-server.spec
@@ -148,6 +148,7 @@ if [ -f %{_sysconfdir}/rabbitmq/rabbitmq.conf ] && [ ! -f %{_sysconfdir}/rabbitm
 fi
 
 chmod -R o-rwx,g-w %{_localstatedir}/lib/rabbitmq/mnesia
+chgrp rabbitmq %{_sysconfdir}/rabbitmq
 
 # Restore permissions saved during %pre. See comment in %pre for the
 # reason behind this.
@@ -218,8 +219,8 @@ systemctl try-restart %{name}.service >/dev/null 2>&1 || :
 %defattr(-,root,root,-)
 %attr(0755, rabbitmq, rabbitmq) %dir %{_localstatedir}/lib/rabbitmq
 %attr(0750, rabbitmq, rabbitmq) %dir %{_localstatedir}/lib/rabbitmq/mnesia
-%attr(0750, rabbitmq, rabbitmq) %dir %{_localstatedir}/log/rabbitmq
-%attr(2750, -, rabbitmq) %dir %{_sysconfdir}/rabbitmq
+%attr(0755, rabbitmq, rabbitmq) %dir %{_localstatedir}/log/rabbitmq
+%attr(2755, -, rabbitmq) %dir %{_sysconfdir}/rabbitmq
 
 %{_sysconfdir}/profile.d/rabbitmqctl-autocomplete.sh
 %{_datarootdir}/zsh/vendor-functions/_enable_rabbitmqctl_completion

--- a/packaging/debs/Debian/debian/postinst
+++ b/packaging/debs/Debian/debian/postinst
@@ -33,7 +33,7 @@ fi
 chown -R rabbitmq:rabbitmq /var/lib/rabbitmq
 chown -R rabbitmq:adm /var/log/rabbitmq
 chgrp rabbitmq /etc/rabbitmq 
-chmod 2750 /etc/rabbitmq
+chmod g+s /etc/rabbitmq
 chmod 750 /var/lib/rabbitmq/mnesia
 chmod -R o-rwx,g-w /var/lib/rabbitmq/mnesia
 


### PR DESCRIPTION
This reverts commit 5df0873777cbb08e7c99ece12c7461c41e78750f.

This makes `/etc/rabbitmq` readable again. Files in `/etc/rabbitmq` was and are still readable, but the directory was not. 

For reference PostgreSQL makes all directories and all but the most sensitive files readable: 

```
$ ls -l /etc/ | grep post
drwxr-xr-x 3 root root    4096 Jun 21  2016 postgresql
drwxr-xr-x 3 root root    4096 Jun 21  2016 postgresql-common
$ ls -l /etc/postgresql
total 4
drwxr-xr-x 3 postgres postgres 4096 Jun 21  2016 9.5
$ ls -l /etc/postgresql/9.5/
total 4
drwxr-xr-x 2 postgres postgres 4096 Jun 21  2016 main
$ ls -l /etc/postgresql/9.5/main/
total 24
-rw-r--r-- 1 postgres postgres  315 Jun 21  2016 environment
-rw-r--r-- 1 postgres postgres  143 Jun 21  2016 pg_ctl.conf
-rw-r----- 1 postgres postgres  296 Jun 21  2016 pg_hba.conf
-rw-r----- 1 postgres postgres 1636 Jun 21  2016 pg_ident.conf
-rw-r--r-- 1 postgres postgres  877 Jun 21  2016 postgresql.conf
-rw-r--r-- 1 postgres postgres  378 Jun 21  2016 start.conf
```