### PR TITLE
Use sysexists exit codes in OCF agent script

### DIFF
--- a/scripts/rabbitmq-server.ocf
+++ b/scripts/rabbitmq-server.ocf
@@ -275,7 +275,7 @@ rabbitmqctl_action() {
             ocf_log debug "RabbitMQ server is running normally"
             return $OCF_SUCCESS
             ;;
-        1|2)
+        1|2|69)
             ocf_log debug "RabbitMQ server is not running"
             return $OCF_NOT_RUNNING
             ;;


### PR DESCRIPTION
Exit codes from sysexits.h were introduced in rabbitmq CLI with
https://github.com/rabbitmq/rabbitmq-server/pull/412. The OCF
agent for non-clustered setup was not updated and some exit codes
were incorrectly reported as unexpected.