### PR TITLE
Use 32768 as the default open files limit

### DIFF
--- a/packaging/RPMS/Fedora/rabbitmq-server.service
+++ b/packaging/RPMS/Fedora/rabbitmq-server.service
@@ -9,10 +9,18 @@ Group=rabbitmq
 UMask=0027
 NotifyAccess=all
 TimeoutStartSec=3600
-# Un-comment this setting if you need to increase RabbitMQ's
-# open files limit
-# LimitNOFILE=16384
+
+# To override LimitNOFILE, create the following file:
 #
+# /etc/systemd/system/rabbitmq-server.service.d/limits.conf
+#
+# with the following content:
+#
+# [Service]
+# LimitNOFILE=65536
+
+LimitNOFILE=32768
+
 # Note: systemd on CentOS 7 complains about in-line comments,
 # so only append them here
 #

--- a/packaging/debs/Debian/debian/rabbitmq-server.service
+++ b/packaging/debs/Debian/debian/rabbitmq-server.service
@@ -11,10 +11,18 @@ Group=rabbitmq
 UMask=0027
 NotifyAccess=all
 TimeoutStartSec=3600
-# Un-comment this setting if you need to increase RabbitMQ's
-# open files limit
-# LimitNOFILE=16384
+
+# To override LimitNOFILE, create the following file:
 #
+# /etc/systemd/system/rabbitmq-server.service.d/limits.conf
+#
+# with the following content:
+#
+# [Service]
+# LimitNOFILE=65536
+
+LimitNOFILE=32768
+
 # The following setting will automatically restart RabbitMQ
 # in the event of a failure. systemd service restarts are not a
 # replacement for service monitoring. Please see


### PR DESCRIPTION
This is on systemd-based systems. Also added a comment on how to override `LimitNOFILE`