### PR TITLE
Do not rename existing rabbitmq.conf file

### DIFF
--- a/packaging/RPMS/Fedora/rabbitmq-server.spec
+++ b/packaging/RPMS/Fedora/rabbitmq-server.spec
@@ -146,10 +146,6 @@ systemctl daemon-reload
 /sbin/chkconfig --add %{name}
 %endif
 
-if [ -f %{_sysconfdir}/rabbitmq/rabbitmq.conf ] && [ ! -f %{_sysconfdir}/rabbitmq/rabbitmq-env.conf ]; then
-    mv %{_sysconfdir}/rabbitmq/rabbitmq.conf %{_sysconfdir}/rabbitmq/rabbitmq-env.conf
-fi
-
 chmod -R o-rwx,g-w %{_localstatedir}/lib/rabbitmq/mnesia
 chgrp rabbitmq %{_sysconfdir}/rabbitmq
 


### PR DESCRIPTION
`rabbitmq.conf` must be a very old way to specify environment variables because the installation moves it to `rabbitmq-env.conf` if found. This is a problem as the new sysctl-style config file is named `rabbitmq.conf`

Fixes #87