### PR TITLE
Remove use of elinks and mandoc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -391,13 +391,7 @@ install-windows-scripts: install-windows-escripts
 
 install-windows-docs: install-windows-erlapp
 	$(verbose) mkdir -p $(DESTDIR)$(WINDOWS_PREFIX)/etc
-	$(inst_verbose) mandoc -T html \
-		< $(DEPS_DIR)/rabbit/docs/rabbitmq-service.8 \
-		> rabbitmq-service.html
-	$(verbose) elinks -dump -no-references -no-numbering \
-		rabbitmq-service.html \
-		> $(DESTDIR)$(WINDOWS_PREFIX)/readme-service.txt
-	$(verbose) rm rabbitmq-service.html
+	$(inst_verbose) man $(DEPS_DIR)/rabbit/docs/rabbitmq-service.8 | col -bx > $(DESTDIR)$(WINDOWS_PREFIX)/readme-service.txt
 	$(verbose) cp $(DEPS_DIR)/rabbit/docs/rabbitmq.config.example \
 		$(DESTDIR)$(WINDOWS_PREFIX)/etc
 	$(verbose) for file in \

--- a/Makefile
+++ b/Makefile
@@ -391,7 +391,9 @@ install-windows-scripts: install-windows-escripts
 
 install-windows-docs: install-windows-erlapp
 	$(verbose) mkdir -p $(DESTDIR)$(WINDOWS_PREFIX)/etc
-	$(inst_verbose) man $(DEPS_DIR)/rabbit/docs/rabbitmq-service.8 | col -bx > $(DESTDIR)$(WINDOWS_PREFIX)/readme-service.txt
+	$(inst_verbose) man $(DEPS_DIR)/rabbit/docs/rabbitmq-service.8 > tmp-readme-service.txt
+	$(verbose) col -bx < ./tmp-readme-service.txt > $(DESTDIR)$(WINDOWS_PREFIX)/readme-service.txt
+	$(verbose) rm -f ./tmp-readme-service.txt
 	$(verbose) cp $(DEPS_DIR)/rabbit/docs/rabbitmq.config.example \
 		$(DESTDIR)$(WINDOWS_PREFIX)/etc
 	$(verbose) for file in \


### PR DESCRIPTION
This allows the Windows package to be built on Windows using [these instructions](https://gist.github.com/lukebakken/f0323f90291b5e5e7bbbe0287c411171).

There is no `mandoc` package for `msys2`, and the `elinks` package is broken, see https://github.com/Alexpux/MSYS2-packages/issues/1479

Tested on a local Debian Jesse VM provisioned by [Vagrant](https://gist.github.com/lukebakken/84fb0db5618e18caa2839a151ccb5ace). The generated `.zip` file contains the expected `readme-service.txt` file in ASCII format.