### PR TITLE
Use restart / restart instead of try-restart

### DIFF
--- a/packaging/RPMS/Fedora/rabbitmq-server.spec
+++ b/packaging/RPMS/Fedora/rabbitmq-server.spec
@@ -189,7 +189,7 @@ done
 # expand correctly on debian machines
 if [ $1 -ge 1 ] ; then
     # Package upgrade, not uninstall
-    systemctl reload-or-restart %{name}.service >/dev/null 2>&1 || :
+    systemctl restart %{name}.service >/dev/null 2>&1 || :
 fi
 %else
 if [ $1 -gt 1 ]; then

--- a/packaging/RPMS/Fedora/rabbitmq-server.spec
+++ b/packaging/RPMS/Fedora/rabbitmq-server.spec
@@ -189,11 +189,12 @@ done
 # expand correctly on debian machines
 if [ $1 -ge 1 ] ; then
     # Package upgrade, not uninstall
-    systemctl try-restart %{name}.service >/dev/null 2>&1 || :
+    systemctl reload-or-restart %{name}.service >/dev/null 2>&1 || :
 fi
 %else
 if [ $1 -gt 1 ]; then
-   /sbin/service %{name} try-restart
+    # Package upgrade, not uninstall
+   /sbin/service %{name} restart
 fi
 %endif
 


### PR DESCRIPTION
Fixes #94 

@dumbbell I'm not sure if [this line](https://github.com/rabbitmq/rabbitmq-server-release/blob/master/packaging/RPMS/Fedora/rabbitmq-server.spec#L211) should be changed to use `restart` as well as I'm not quite sure what is being accomplished there.

Tested using this Vagrantfile on CentOS 7 - 
[Vagrantfile.txt](https://github.com/rabbitmq/rabbitmq-server-release/files/2937768/Vagrantfile.txt)

You can see `rabbitmqctl status` failing after the upgrade because RabbitMQ is not restarted. Running `systemctl restart rabbitmq-server` does re-start RabbitMQ.
