### PR TITLE
Debian systemd: Consider exit code 69 as success again

### DIFF
--- a/packaging/debs/Debian/debian/rabbitmq-server.service
+++ b/packaging/debs/Debian/debian/rabbitmq-server.service
@@ -33,6 +33,7 @@ WorkingDirectory=/var/lib/rabbitmq
 ExecStart=/usr/lib/rabbitmq/bin/rabbitmq-server
 ExecStop=/usr/lib/rabbitmq/bin/rabbitmqctl shutdown
 # See rabbitmq/rabbitmq-server-release#51
+SuccessExitStatus=69
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This was first added in e5a2609fcb0479d2867432254658b3481f9e2d48 but then accidentally removed, it seems, in https://github.com/rabbitmq/rabbitmq-server-release/commit/c641f7bb5141f4df4754cb9d0e3a053bc99960a2#diff-bc10308ed9f9f0d177ebb09adca37edcL22

Related to #51.

I consider the change trivial so I don't think there's a need to sign the Contributor Agreement. I will if you need me to.