### PR TITLE
Simplify packaging after rabbitmq-server(8) move to Erlang code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -404,23 +404,11 @@ install-erlapp: dist
 	$(verbose) mkdir -p $(DESTDIR)$(RMQ_ERLAPP_DIR)
 	$(inst_verbose) cp -r \
 		LICENSE* \
-		$(DEPS_DIR)/rabbit/ebin \
-		$(DEPS_DIR)/rabbit/priv \
 		$(DEPS_DIR)/rabbit/INSTALL \
 		$(DIST_DIR) \
 		$(DESTDIR)$(RMQ_ERLAPP_DIR)
 	$(verbose) echo "Put your EZs here and use rabbitmq-plugins to enable them." \
 		> $(DESTDIR)$(RMQ_ERLAPP_DIR)/$(notdir $(DIST_DIR))/README
-
-	@# FIXME: Why do we copy headers?
-	$(verbose) cp -r \
-		$(DEPS_DIR)/rabbit/include \
-		$(DESTDIR)$(RMQ_ERLAPP_DIR)
-	@# rabbitmq-common provides headers too: copy them to
-	@# rabbitmq_server/include.
-	$(verbose) cp -r \
-		$(DEPS_DIR)/rabbit_common/include \
-		$(DESTDIR)$(RMQ_ERLAPP_DIR)
 
 CLI_ESCRIPTS_DIR = escript
 

--- a/Makefile
+++ b/Makefile
@@ -378,8 +378,7 @@ SCRIPTS = rabbitmq-defaults \
 	  rabbitmq-plugins \
 	  rabbitmq-diagnostics \
 	  rabbitmq-queues \
-	  rabbitmq-upgrade \
-	  cuttlefish
+	  rabbitmq-upgrade
 
 AUTOCOMPLETE_SCRIPTS = bash_autocomplete.sh zsh_autocomplete.sh
 
@@ -392,8 +391,7 @@ WINDOWS_SCRIPTS = rabbitmq-defaults.bat \
 		  rabbitmq-server.bat \
 		  rabbitmq-service.bat \
 		  rabbitmq-upgrade.bat \
-		  rabbitmqctl.bat \
-		  cuttlefish
+		  rabbitmqctl.bat
 
 UNIX_TO_DOS ?= todos
 


### PR DESCRIPTION
This pull request is part of the effort to move rabbitmq-server(8) scripts to Erlang code and transform the `rabbit` application in a regular Erlang/OTP application (rabbitmq/rabbitmq-server#2180).

This patch simplifies our packaging in the following areas:
* The `cuttlefish` executable is gone!
* `rabbit` being packaged as an `.ez` archive like plugins, we don't need to copy specific directories from the `rabbit` application.