### PR TITLE
Allow operator to disable iptables client blocking

### DIFF
--- a/scripts/rabbitmq-server-ha.ocf
+++ b/scripts/rabbitmq-server-ha.ocf
@@ -52,6 +52,7 @@ OCF_RESKEY_policy_file_default="/usr/local/sbin/set_rabbitmq_policy"
 OCF_RESKEY_rmq_feature_health_check_default=true
 OCF_RESKEY_rmq_feature_local_list_queues_default=true
 OCF_RESKEY_limit_nofile_default=65535
+OCF_RESKEY_avoid_using_iptables_default=false
 
 : ${HA_LOGTAG="lrmd"}
 : ${HA_LOGFACILITY="daemon"}
@@ -78,6 +79,7 @@ OCF_RESKEY_limit_nofile_default=65535
 : ${OCF_RESKEY_rmq_feature_health_check=${OCF_RESKEY_rmq_feature_health_check_default}}
 : ${OCF_RESKEY_rmq_feature_local_list_queues=${OCF_RESKEY_rmq_feature_local_list_queues_default}}
 : ${OCF_RESKEY_limit_nofile=${OCF_RESKEY_limit_nofile_default}}
+: ${OCF_RESKEY_avoid_using_iptables=${OCF_RESKEY_avoid_using_iptables_default}}
 
 #######################################################################
 
@@ -355,6 +357,15 @@ Soft and hard limit for NOFILE
 </longdesc>
 <shortdesc lang="en">NOFILE limit</shortdesc>
 <content type="string" default="${OCF_RESKEY_limit_nofile_default}" />
+</parameter>
+
+<parameter name="avoid_using_iptables" unique="0" required="0">
+<longdesc lang="en">
+When set to true the iptables calls to block client access become
+noops. This is useful when we run inside containers.
+</longdesc>
+<shortdesc lang="en">Disable iptables use entirely</shortdesc>
+<content type="boolean" default="${OCF_RESKEY_avoid_using_iptables_default}" />
 </parameter>
 
 $EXTENDED_OCF_PARAMS
@@ -764,6 +775,10 @@ reset_mnesia() {
 
 block_client_access()
 {
+    # When OCF_RESKEY_avoid_using_iptables is true iptables calls are noops
+    if [ "${OCF_RESKEY_avoid_using_iptables}" == 'true' ] ; then
+        return $OCF_SUCCESS
+    fi
     # do not add temporary RMQ blocking rule, if it is already exist
     # otherwise, try to add a blocking rule with max of 5 retries
     local tries=5
@@ -782,6 +797,10 @@ block_client_access()
 
 unblock_client_access()
 {
+    # When OCF_RESKEY_avoid_using_iptables is true iptables calls are noops
+    if [ "${OCF_RESKEY_avoid_using_iptables}" == 'true' ] ; then
+        return
+    fi
     # remove all temporary RMQ blocking rules, if there are more than one exist
     for i in $(iptables -nvL --wait --line-numbers | awk '/temporary RMQ block/ {print $1}'); do
       iptables --wait -D INPUT -p tcp -m tcp --dport ${OCF_RESKEY_node_port} -m state --state NEW,RELATED,ESTABLISHED \


### PR DESCRIPTION
Currently the resource agent hard-codes iptables calls to block off
client access before the resource becomes master. This was done
historically because many libraries were fairly buggy detecting a
not-yet functional rabbitmq, so they were being helped by getting
a tcp RST packet and they would go on trying their next configured
server.

It makes sense to be able to disable this behaviour because
most libraries by now have gotten better at detecting timeouts when
talking to rabbit and because when you run rabbitmq inside a bundle
(pacemaker term for a container with an OCF resource inside) you
normally do not have access to iptables.

Tested by creating a three-node bundle cluster inside a container:
 Container bundle set: rabbitmq-bundle [cluster.common.tag/rhosp16-openstack-rabbitmq:pcmklatest]
   Replica[0]
      rabbitmq-bundle-podman-0  (ocf::heartbeat:podman):        Started controller-0
      rabbitmq-bundle-0 (ocf::pacemaker:remote):        Started controller-0
      rabbitmq  (ocf::rabbitmq:rabbitmq-server-ha):     Master rabbitmq-bundle-0
   Replica[1]
      rabbitmq-bundle-podman-1  (ocf::heartbeat:podman):        Started controller-1
      rabbitmq-bundle-1 (ocf::pacemaker:remote):        Started controller-1
      rabbitmq  (ocf::rabbitmq:rabbitmq-server-ha):     Master rabbitmq-bundle-1
   Replica[2]
      rabbitmq-bundle-podman-2  (ocf::heartbeat:podman):        Started controller-2
      rabbitmq-bundle-2 (ocf::pacemaker:remote):        Started controller-2
      rabbitmq  (ocf::rabbitmq:rabbitmq-server-ha):     Master rabbitmq-bundle-2

The ocf resource was created inside a bundle with:
pcs resource create rabbitmq ocf:rabbitmq:rabbitmq-server-ha avoid_using_iptables="true" \
  meta notify=true container-attribute-target=host master-max=3 ordered=true \
  op start timeout=200s stop timeout=200s promote timeout=60s bundle rabbitmq-bundle

Signed-off-by: Michele Baldessari <michele@acksyn.org>