### PR TITLE
Fix upstream Travis CI for rabbitmq-server-ha

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,14 @@ git:
 env:
   global:
     TRAVIS_BRANCH=travis_ocf_ra
-    RABBIT_VER=false
-    VAGRANT_VERSION=1.8.7
-    DOCKER_IMAGE=bogdando/rabbitmq-cluster-ocf-xenial
+    VAGRANT_VERSION=2.2.5
+    DOCKER_IMAGE=bogdando/rabbitmq-cluster-ocf
     UPLOAD_METHOD=none
     OCF_RA_PROVIDER=rabbitmq
+    OCF_RA_TYPE=rabbitmq-server-ha
+    STORAGE=/var/tmp/rmq
+    # Encodes ha-policy: ${OCF_RESKEY_ctl} set_policy ha-all "jepsen." '{"ha-mode":"exactly", "ha-params":3, "ha-sync-mode":"automatic"}'
+    POLICY_BASE64=IyBUaGlzIHNjcmlwdCBpcyBjYWxsZWQgYnkgcmFiYml0bXEtc2VydmVyLWhhLm9jZiBkdXJpbmcgUmFiYml0TVEKIyBjbHVzdGVyIHN0YXJ0IHVwLiBJdCBpcyBhIGNvbnZlbmllbnQgcGxhY2UgdG8gc2V0IHlvdXIgY2x1c3RlcgojIHBvbGljeSBoZXJlLCBmb3IgZXhhbXBsZToKIyAke09DRl9SRVNLRVlfY3RsfSBzZXRfcG9saWN5IGhhLWFsbCAiLiIgJ3siaGEtbW9kZSI6ImFsbCIsICJoYS1zeW5jLW1vZGUiOiJhdXRvbWF0aWMiLCAiaGEtc3luYy1iYXRjaC1zaXplIjoxMDAwMH0nCgojIEVuYWJsZSBoYS1wb2xpY3kgd2l0aCB0aGUgcmVwbGljYSBmYWN0b3Igb2YgNSBmb3IgamVwc2VuIHF1ZXVlcwpvY2ZfbG9nIGluZm8gIiR7TEh9IFNldHRpbmcgSEEgcG9saWN5IGZvciBhbGwgcXVldWVzIgoke09DRl9SRVNLRVlfY3RsfSBzZXRfcG9saWN5IGhhLWFsbCAiamVwc2VuLiIgJ3siaGEtbW9kZSI6ImV4YWN0bHkiLCAiaGEtcGFyYW1zIjozLCAiaGEtc3luYy1tb2RlIjoiYXV0b21hdGljIn0nCg==
     CACHE=/var/tmp/releases
     DOCKER_MOUNTS="${HOME}/${OCF_RA_PROVIDER}:/usr/lib/ocf/resource.d/${OCF_RA_PROVIDER}/${OCF_RA_PROVIDER}:ro jepsen:/jepsen"
     DOCKER_DRIVER=aufs
@@ -33,12 +36,12 @@ env:
       NODES="n1 n2 n3"
 
 matrix:
-  allow_failures:                                                                                                                                     
+  allow_failures:
     - env: USE_JEPSEN=true QUIET=false SMOKETEST_WAIT=900 CPU=250 MEMORY=320M NODES="n1 n2 n3"
 
 before_cache:
   # Save tagged docker images
-  - mkdir -p $CACHE 
+  - mkdir -p $CACHE
   - docker save $(docker images -a --filter='dangling=false' --format '{{.Repository}}:{{.Tag}} {{.ID}}') -o $CACHE/all.tar
 
 cache:
@@ -69,4 +72,3 @@ before_install:
 
 script:
   - vagrant up
-

--- a/scripts/rabbitmq-server-ha.ocf
+++ b/scripts/rabbitmq-server-ha.ocf
@@ -1,4 +1,5 @@
 #!/bin/sh
+# testing
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at


### PR DESCRIPTION
Poke versions from the newest container image, which uses:
  - Debian Buster
  - rabbitmq-server 3.7.8-4
  - Pacemaker 2.0.1-5
  - Corosync 3.0.1-2
  - pcs 0.10.1-2
  - crmsh 4.0.0~git20190108.3d56538-3

Also add an ha-policy-file (base64 encoded) for Travis CI jobs.

Signed-off-by: Bogdan Dobrelya <bogdando@mail.ru>