### PR TITLE
Use `J` tar flag for extracting `.tar.xz`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -357,7 +357,7 @@ $(PACKAGES_DIR)/rabbitmq-server-generic-unix-$(PROJECT_VERSION).tar.xz:
 OTP_VERSION := 22.2.8
 OTP_SHA256 := 71f73ddd59db521928a0f6c8d4354d6f4e9f4bfbd0b40d321cd5253a6c79b095
 docker-image: $(PACKAGES_DIR)/rabbitmq-server-generic-unix-$(PROJECT_VERSION).tar.xz
-	$(verbose) (cd PACKAGES && tar xjvf rabbitmq-server-generic-unix-$(PROJECT_VERSION).tar.xz) \
+	$(verbose) (cd PACKAGES && tar xJvf rabbitmq-server-generic-unix-$(PROJECT_VERSION).tar.xz) \
 	&& docker build --pull \
 	  --build-arg PGP_KEYSERVER=pgpkeys.uk \
 	  --build-arg OTP_VERSION=$(OTP_VERSION) \


### PR DESCRIPTION
When making `docker-image`

Ubuntu 18 fails to build the image unless tar is invoked with the capital J