### PR TITLE
Backport "Make RabbitMQ a regular Erlang/OTP application" to RabbitMQ 3.8.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -408,23 +408,11 @@ install-erlapp: dist
 	$(verbose) mkdir -p $(DESTDIR)$(RMQ_ERLAPP_DIR)
 	$(inst_verbose) cp -r \
 		LICENSE* \
-		$(DEPS_DIR)/rabbit/ebin \
-		$(DEPS_DIR)/rabbit/priv \
 		$(DEPS_DIR)/rabbit/INSTALL \
 		$(DIST_DIR) \
 		$(DESTDIR)$(RMQ_ERLAPP_DIR)
 	$(verbose) echo "Put your EZs here and use rabbitmq-plugins to enable them." \
 		> $(DESTDIR)$(RMQ_ERLAPP_DIR)/$(notdir $(DIST_DIR))/README
-
-	@# FIXME: Why do we copy headers?
-	$(verbose) cp -r \
-		$(DEPS_DIR)/rabbit/include \
-		$(DESTDIR)$(RMQ_ERLAPP_DIR)
-	@# rabbitmq-common provides headers too: copy them to
-	@# rabbitmq_server/include.
-	$(verbose) cp -r \
-		$(DEPS_DIR)/rabbit_common/include \
-		$(DESTDIR)$(RMQ_ERLAPP_DIR)
 
 CLI_ESCRIPTS_DIR = escript
 

--- a/Makefile
+++ b/Makefile
@@ -382,8 +382,7 @@ SCRIPTS = rabbitmq-defaults \
 	  rabbitmq-plugins \
 	  rabbitmq-diagnostics \
 	  rabbitmq-queues \
-	  rabbitmq-upgrade \
-	  cuttlefish
+	  rabbitmq-upgrade
 
 AUTOCOMPLETE_SCRIPTS = bash_autocomplete.sh zsh_autocomplete.sh
 
@@ -396,8 +395,7 @@ WINDOWS_SCRIPTS = rabbitmq-defaults.bat \
 		  rabbitmq-server.bat \
 		  rabbitmq-service.bat \
 		  rabbitmq-upgrade.bat \
-		  rabbitmqctl.bat \
-		  cuttlefish
+		  rabbitmqctl.bat
 
 UNIX_TO_DOS ?= todos
 

--- a/packaging/RPMS/Fedora/rabbitmq-server.init
+++ b/packaging/RPMS/Fedora/rabbitmq-server.init
@@ -25,7 +25,7 @@ CONTROL=/usr/sbin/rabbitmqctl
 DESC=rabbitmq-server
 USER=rabbitmq
 PID_FILE=/var/run/rabbitmq/pid
-RABBITMQ_ENV=/usr/lib/rabbitmq/bin/rabbitmq-env
+RABBITMQ_LOG_BASE=/var/log/rabbitmq
 
 START_PROG= # Set when building package
 LOCK_FILE=/var/lock/subsys/$NAME
@@ -37,9 +37,6 @@ RETVAL=0
 set -e
 
 [ -f /etc/default/${NAME} ] && . /etc/default/${NAME}
-
-RABBITMQ_SCRIPTS_DIR=$(dirname "$RABBITMQ_ENV")
-. "$RABBITMQ_ENV"
 
 ensure_pid_dir () {
     PID_DIR=`dirname ${PID_FILE}`

--- a/packaging/debs/Debian/debian/control
+++ b/packaging/debs/Debian/debian/control
@@ -43,7 +43,7 @@ Build-Depends: debhelper (>= 9),
  erlang-dev (<< 1:23.0) | esl-erlang (<< 1:23.0),
  erlang-src (>= 1:21.3) | esl-erlang (>= 1:21.3),
  erlang-src (<< 1:23.0) | esl-erlang (<< 1:23.0),
- elixir (>= 1.7.4),
+ elixir (>= 1.8.0),
  zip,
  rsync
 Standards-Version: 3.9.6

--- a/packaging/debs/Debian/debian/rabbitmq-server.init
+++ b/packaging/debs/Debian/debian/rabbitmq-server.init
@@ -23,7 +23,7 @@ CONTROL=/usr/sbin/rabbitmqctl
 DESC="message broker"
 USER=rabbitmq
 PID_FILE=/var/run/rabbitmq/pid
-RABBITMQ_ENV=/usr/lib/rabbitmq/bin/rabbitmq-env
+RABBITMQ_LOG_BASE=/var/log/rabbitmq
 
 test -x $DAEMON || exit 0
 test -x $CONTROL || exit 0
@@ -32,9 +32,6 @@ RETVAL=0
 set -e
 
 [ -f /etc/default/${NAME} ] && . /etc/default/${NAME}
-
-RABBITMQ_SCRIPTS_DIR=$(dirname "$RABBITMQ_ENV")
-. "$RABBITMQ_ENV"
 
 . /lib/lsb/init-functions
 . /lib/init/vars.sh

--- a/scripts/rabbitmq-script-wrapper
+++ b/scripts/rabbitmq-script-wrapper
@@ -16,8 +16,7 @@
 ##
 
 SCRIPT="$(basename "$0")"
-RABBITMQ_ENV=/usr/lib/rabbitmq/bin/rabbitmq-env
-RABBITMQ_SCRIPTS_DIR="$(dirname "$RABBITMQ_ENV")"
+RABBITMQ_LOG_BASE=/var/log/rabbitmq
 
 main() {
   ensure_we_are_in_a_readable_dir
@@ -72,13 +71,6 @@ calling_rabbitmq_plugins() {
 }
 
 exec_rabbitmq_server() {
-  RABBITMQ_ENV=/usr/lib/rabbitmq/bin/rabbitmq-env
-  # RABBITMQ_SCRIPTS_DIR is used in rabbitmq-env
-  # shellcheck disable=SC2034
-  RABBITMQ_SCRIPTS_DIR="$(dirname "$RABBITMQ_ENV")"
-  # shellcheck source=/dev/null
-  . "$RABBITMQ_ENV"
-
   exec /usr/lib/rabbitmq/bin/rabbitmq-server "$@" @STDOUT_STDERR_REDIRECTION@
 }
 


### PR DESCRIPTION
This is a backport of patches related to rabbitmq/rabbitmq-server#2180.

Note that this pull request **MUST NOT be merged** without its equivalents in other repositories!

The progress is tracked in rabbitmq/rabbitmq-server#2280.