### PR TITLE
Add timeout to rabbitmqctl wait statement

### DIFF
--- a/packaging/RPMS/Fedora/rabbitmq-server.init
+++ b/packaging/RPMS/Fedora/rabbitmq-server.init
@@ -26,6 +26,7 @@ DESC=rabbitmq-server
 USER=rabbitmq
 PID_FILE=/var/run/rabbitmq/pid
 RABBITMQ_LOG_BASE=/var/log/rabbitmq
+RABBITMQ_STARTUP_TIMEOUT=600
 
 START_PROG= # Set when building package
 LOCK_FILE=/var/lock/subsys/$NAME
@@ -64,7 +65,7 @@ start_rabbitmq () {
             > "${RABBITMQ_LOG_BASE}/startup_log" \
             2> "${RABBITMQ_LOG_BASE}/startup_err" \
             0<&- &
-        $CONTROL wait $PID_FILE >/dev/null 2>&1
+        $CONTROL wait --timeout $RABBITMQ_STARTUP_TIMEOUT $PID_FILE >/dev/null 2>&1
         RETVAL=$?
         set -e
         case "$RETVAL" in

--- a/packaging/RPMS/Fedora/rabbitmq-server.service
+++ b/packaging/RPMS/Fedora/rabbitmq-server.service
@@ -8,7 +8,7 @@ User=rabbitmq
 Group=rabbitmq
 UMask=0027
 NotifyAccess=all
-TimeoutStartSec=3600
+TimeoutStartSec=600
 
 # To override LimitNOFILE, create the following file:
 #

--- a/packaging/debs/Debian/debian/rabbitmq-server.init
+++ b/packaging/debs/Debian/debian/rabbitmq-server.init
@@ -24,6 +24,7 @@ DESC="message broker"
 USER=rabbitmq
 PID_FILE=/var/run/rabbitmq/pid
 RABBITMQ_LOG_BASE=/var/log/rabbitmq
+RABBITMQ_STARTUP_TIMEOUT=600
 
 test -x $DAEMON || exit 0
 test -x $CONTROL || exit 0
@@ -59,7 +60,7 @@ start_rabbitmq () {
         RABBITMQ_PID_FILE=$PID_FILE start-stop-daemon --quiet \
             --chuid rabbitmq --start --exec $DAEMON \
             --pidfile "$PID_FILE" --background
-        $CONTROL wait $PID_FILE >/dev/null 2>&1
+        $CONTROL wait --timeout $RABBITMQ_STARTUP_TIMEOUT $PID_FILE >/dev/null 2>&1
         RETVAL=$?
         set -e
         if [ $RETVAL != 0 ] ; then

--- a/packaging/debs/Debian/debian/rabbitmq-server.service
+++ b/packaging/debs/Debian/debian/rabbitmq-server.service
@@ -10,7 +10,7 @@ User=rabbitmq
 Group=rabbitmq
 UMask=0027
 NotifyAccess=all
-TimeoutStartSec=3600
+TimeoutStartSec=600
 
 # To override LimitNOFILE, create the following file:
 #


### PR DESCRIPTION
After starting the RabbitMQ server process, the startup script will
wait for the server to start by calling `rabbitmqctl wait` and will
time out after 10 s.

The startup time of the server depends on how quickly the Mnesia
database becomes available and the server will time out after
`mnesia_table_loading_retry_timeout` ms times
`mnesia_table_loading_retry_limit` retries. By default this wait is
30,000 ms times 10 retries, i.e. 300 s.

The mismatch between these two timeout values might lead to the
startup script failing prematurely while the server is still waiting
for the Mnesia tables.

This change introduces a variable and the `--timeout` option into the
startup script so that the two timeout values are identical.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>