### PR TITLE
Update debian/watch file to pull from GitHub

### DIFF
--- a/packaging/debs/Debian/debian/watch
+++ b/packaging/debs/Debian/debian/watch
@@ -1,4 +1,4 @@
-version=3
-
-https://www.rabbitmq.com/releases/rabbitmq-server/v(.*)/rabbitmq-server-(\d.*)\.tar\.gz \
-	debian uupdate
+version=4
+opts="filenamemangle=s%(?:.*?)?v?@PACKAGE@-(\d[\d.]*)\.tar\.xz%@PACKAGE@-$1.tar.xz%" \
+      https://github.com/rabbitmq/@PACKAGE@/releases \
+      (?:.*?/)?v?@PACKAGE@-(\d[\d.]*)\.tar\.xz debian uupdate


### PR DESCRIPTION
RabbitMQ is released on GitHub. Update the `debian/watch` file to
point to this location.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>