### PR TITLE
Add files to specify license info

### DIFF
--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -1,0 +1,15 @@
+---
+- - :license
+  - cuttlefish
+  - Apache 2.0
+  - :who:
+    :why:
+    :versions: []
+    :when: 2020-08-18 19:39:01.911854263 Z
+- - :license
+  - getopt
+  - New BSD
+  - :who:
+    :why:
+    :versions: []
+    :when: 2020-08-18 19:39:16.203102298 Z


### PR DESCRIPTION
Created via these commands:

```
(23.0.3)lbakken@shostakovich ~/development/rabbitmq/LicenseFinder (master %=)
$ bundle exec license_finder licenses add cuttlefish 'Apache 2.0' --project-path /home/lbakken/development/rabbitmq/rabbitmq-server-release
The cuttlefish dependency has been marked as using Apache 2.0 license!

(23.0.3)lbakken@shostakovich ~/development/rabbitmq/LicenseFinder (master %=)
$ bundle exec license_finder licenses add getopt 'New BSD' --project-path /home/lbakken/development/rabbitmq/rabbitmq-server-release
The getopt dependency has been marked as using New BSD license!

(23.0.3)lbakken@shostakovich ~/development/rabbitmq/LicenseFinder (master %=)
$ bundle exec license_finder action_items --prepare --project-path /home/lbakken/development/rabbitmq/rabbitmq-server-release
```