### PR TITLE
Update minimum required Elixir version

### DIFF
--- a/packaging/debs/Debian/debian/control
+++ b/packaging/debs/Debian/debian/control
@@ -43,7 +43,7 @@ Build-Depends: debhelper (>= 9),
  erlang-dev (<< 1:24.0) | esl-erlang (<< 1:24.0),
  erlang-src (>= 1:22.3) | esl-erlang (>= 1:22.3),
  erlang-src (<< 1:24.0) | esl-erlang (<< 1:24.0),
- elixir (>= 1.8.0),
+ elixir (>= 1.9.0),
  zip,
  rsync
 Standards-Version: 3.9.6


### PR DESCRIPTION
See https://github.com/rabbitmq/rabbitmq-ci/pull/33

Part of an effort to use Elixir 1.9 as the minimum.

cc @dumbbell

PS I couldn't see a minimum Elixir version specified in the rpm packaging :shrug: 