### PR TITLE
Capture and return rabbitmq-plugins exit code in rabbitmq-script-wrapper

### DIFF
--- a/scripts/rabbitmq-script-wrapper
+++ b/scripts/rabbitmq-script-wrapper
@@ -20,7 +20,9 @@ main() {
   elif current_user_is_root && calling_rabbitmq_plugins
   then
     run_script_as_rabbitmq "$@"
+    result=$?
     maybe_fixup_erlang_cookie
++   exit $result
   elif current_user_is_root
   then
     exec_script_as_root "$@"


### PR DESCRIPTION
The wrapper was returning the exit code of `maybe_fixup_erlang_cookie`, and the exit code of `rabbitmq-plugins` was lost.